### PR TITLE
Update consistent_mirrored.md

### DIFF
--- a/en/docs/extended_topics/consistent_mirrored.md
+++ b/en/docs/extended_topics/consistent_mirrored.md
@@ -6,74 +6,72 @@ In this article, we will introduce:
 
 * The difference and applicable scenario of data parallelism and model parallelism.
 
-* The characteristics of using  `mirrored`  in distributed training.
+* The characteristics of `mirrored` view in distributed training.
 
-* The characteristics of using  `consistent` in distributed training.
+* The characteristics of `consistent` view in distributed training.
 
 ## Data parallelism and model parallelism.
-In order to better understand  `consistent` and `mirrored` in OneFlow. We need to understand the difference between **data parallelism **and **model parallelism** in distributed training.
+In order to better understand  `consistent` and `mirrored` in OneFlow, we need to understand the difference between **data parallelism** and **model parallelism** in distributed training.
 
-To further demonstrate the difference between data parallelism and model parallelism, we will introduce a simple operator(In OneFlow, the logical calculation will be regarded as operator): matrix multiplication. 
+To further demonstrate the difference between data parallelism and model parallelism, we will introduce a simple operator (In OneFlow, the logical calculation will be regarded as operator): matrix multiplication. 
 
-We assume that in model training, there is an input matrix I, and the output matrix O is obtained by matrix multiplication of matrix I and matrix W. 
+Let's take the matrix multiplication as an example. We denote the input, weight, and output matrix by I, W, O respectively.
 
 ![I×W](imgs/i_mul_w.png)
 
-As the description above, size of I is (N, C1), size of W is (C1, C2) and size of O is (N, C2).
+As shown in the figure, the size of I is (N, C1), the size of W is (C1, C2) and the size of O is (N, C2).
 
-Combined machine learning logic, we can give some definitions to the matrixes above:
+In machine learning, we can describe the matrixes as following:
 
-* Matrix I is the input object, each row is a sample and each column represents the features of sample.
+* Matrix I is the input object, each row is a sample and each column represents the features of the sample.
 
-* Matrix W represents the parameters of model.
+* Matrix W represents the parameters of the model.
 
-* Matrix O is the prediction result or label. If it is a predicting task, it is a process of solving O by I and W to get the classification result. If it is a training task, it is a process of solving for W by I and O.
+* Matrix O is the prediction result.
 
-When the row N in matrix I is very large. It means we have a large scale samples. If C2 in matrix W is very large, it means we have a very complex model. If the scale and complexity reach a point. The single machine with single device will not able to handle the training job. We might consider the distributed training. In distributed training system, we can choose **data parallelism** and **model parallelism**.
-
+If `N` in the matrix I is very large, we have large-scale samples. If `C2` in matrix W is very large, it means we have a very complex model. If the scale and complexity reach a point, the single machine with a single device will not able to handle the training job. We might consider the distributed training. In a distributed training system, we can choose **data parallelism** and **model parallelism**.
 
 In order to better understand data parallelism and model parallelism, we use the following figure as the demo of matrix multiplication:
 
 ![mat_mul_op](imgs/mul_op_illustrated.png)
 
-The first matrix in grey on the left of equation is the input sample. Each row is a sample. The second matrix in blue on the left of equation is the model.
+The first matrix in grey on the left-hand side of the equation is the input sample. Each row is a sample. The second matrix in blue on the left-hand side of the equation is the parameter(model).
 
-In this section, we will see the operators above switching to different way under data parallelism and model parallelism.
+In this section, we will see how the operators above are split in different ways in data parallelism and model parallelism.
 
 
 ### Data parallelism diagram
 
-In **data parallelism**, the sample data are divided in small parts. **The divided data** will send to each training nodes and calculate with the **complete models**. Finally we combine the information in each nodes. As shown in the figure below:
+In **data parallelism**, the sample data are divided into small parts. **The divided data** will send to each training nodes and calculate with the **complete models**. Finally, we combine the information in each node. As shown in the figure below:
 
 ![mat_mul_op](imgs/mul_op_data_parr.png)
 
 ### Model parallelism diagram
 
-In **model parallelism**, model will be divided. **Complete data** will be sent to each nodes and calculate with **model after dividing**. Finally we combine the model in each nodes. As shown in the figure below:
+In **model parallelism**, the model will be divided. **Complete data** will be sent to each node and calculate with **the divided model**. Finally, we combine the model in each node. As shown in the figure below:
 
 ![mat_mul_op](imgs/mul_op_model_parr.png)
 
 In a word:
 
-* In data parallelism, each node use the same model to train, data will be divided.
+* In data parallelism, each node uses the same model to train and the data is divided.
 
-* In model parallelism, each node received same data, model will be divided.
+* In model parallelism, each node receives the same data and the model is divided.
 
 We will introduce two parallelism strategies in OneFlow (`mirrored` and `consistent`) and learn how to choose different parallelism methods in different strategies.
 
 ### Two types of Placeholder
 In [use OneFlow build neural network](../basics_topics/build_nn_with_op_and_layer.md), we have already introduced the concept of  `Placeholder` and `Blob`. 
 
-Actually, in the view of parallelism, the  `Placeholder` of OneFlow can be divided to two types: Use `oneflow.typing.Numpy.Placeholder` and `oneflow.typing.ListNumpy.Placeholder` to construct the placeholder, which is corresponding to `Consistent`  and `Mirrored`.
+Actually, in the view of parallelism, the  `Placeholder` of OneFlow can be divided into two types: Use `oneflow.typing.Numpy.Placeholder` and `oneflow.typing.ListNumpy.Placeholder` to construct the placeholder, which is corresponding to `Consistent`  and `Mirrored`.
 
-We will explain in details in the examples below.
-
+We will explain them in detail in the examples below.
 
 ## Using mirrored view in OneFlow
 
-Other framework like TensorFlow or Pytorch supports mirrored view. The mirrored view of OneFlow is similar to them.
+Other frameworks like TensorFlow or Pytorch support mirrored view. The mirrored view of OneFlow is similar to them.
 
-In mirrored view, the model are copied in each GPU, the graph building of each node is the same, thus we can only use **data parallelism**.
+In mirrored view, the model are copied in each GPU, the graph building on each node is the same, thus we can only use **data parallelism**.
 
 In OneFlow, the default strategy is consistent view, so you should use `default_logical_view` of  `flow.function_config()` to define:
 
@@ -82,18 +80,19 @@ In OneFlow, the default strategy is consistent view, so you should use `default_
     func_config.default_logical_view(flow.scope.mirrored_view())
 ```
 
-In `mirrored_view`, we can only use **data parallelism**. When we call the job function, we need divide the data in average according to amount of the devices and put the data after dividing into `list`. Every element in `list` is the data to send to **each device**.
+In `mirrored_view`, we can only use **data parallelism**. When we call the job function, we need to divide the data evenly according to the amount of the devices and put the data after dividing it into a `list`. Every element in the `list` is the data to send to **each device**.
 
-The return value type of job function is `oneflow.typing.ListNumpy`. Every element in  `list` is corresponding to the results of each device.
+The return value type of job function is `oneflow.typing.ListNumpy`. Every element in the `list` is corresponding to the results of each device.
 
-**Combined all **elements in the `list` can make a complete BATCH.
+**Concat** all elements in the `list` can make a complete batch.
 
 ### Code Example
+
 In the following code, we use `mirrored_view` with two devices to train.
 
 Complete Code: [mirrored_strategy.py](../code/extended_topics/mirrored_strategy.py)
 
-The key part of the description please refer to "code explanation" later section.
+We will explain the key part of the code in detail in the following "code explanation" later section
 
 ```python
 import numpy as np
@@ -160,6 +159,7 @@ if __name__ == "__main__":
 ```
 
 ### Code explanation
+
 In the above code:
 
 * Use  `flow.config.gpu_device_num` to set device amount as 2.
@@ -175,7 +175,7 @@ def train_job(
 ) -> tp.ListNumpy:
 ```
 
-* The data after dividing need to be stored in the `list` and passed to training functions. The number of elements in `list` need to be same as the **amount of devices in training**. OneFlow will pass the data according to the order of the elements in `list ` to each device(the number i element in `list` is corresponding to number i device):
+* The data after dividing need to be stored in the `list` and passed to training functions. The number of elements in `list` need to be same as the **amount of devices in the training process**. The i-th element in `list` will be sent to the i-th device:
 ```python
   images1 = images[:BATCH_SIZE_PER_GPU]
   images2 = images[BATCH_SIZE_PER_GPU:]
@@ -188,7 +188,7 @@ def train_job(
   loss = train_job(imgs_list, labels_list)
 ```
 
-* The return result `loss` is a `list`, the number of elements in this `list` need to be same as **the amount of devices in training process**. Then we combine them and print the `total_loss`. 
+* The return result `loss` is a `list`, the number of elements in this `list` need to be same as **the amount of devices in the training process**. Then we concat them and print the `total_loss`. 
 ```python
  total_loss = np.array([*loss[0], *loss[1]])
   if i % 20 == 0:
@@ -196,9 +196,9 @@ def train_job(
 ```
 
 ## Use consistent view in OneFlow
-We have already learned about the mirrored view. In `mirrored_view`, sample will be distributed in average to many same models to train. The results of each nodes need to be assembled to get the complete batch.
+We have already learned about the mirrored view, where samples will be distributed evenly while the models are the same in every device, and the results of each node need to be assembled to get the complete batch.
 
-In addition to mirrored view, OneFlow also provides consistent view. Consistent view is one of the features of OneFlow. Compared with mirrored view, it has a great advantage
+In addition to mirrored view, OneFlow also provides consistent view. Consistent view is one of the features of OneFlow. Compared with mirrored view, it has a great advantage.
 
 OneFlow will use consistent view as default. We can declare it explicitly as the following code. 
 ```python
@@ -208,10 +208,10 @@ OneFlow will use consistent view as default. We can declare it explicitly as the
 
 The reason why consistent view is the main feature of OneFlow is that in OneFlow design, if we use `consistent_view`, the op and blob can **get consistently in logic level** from user's point of view. We use matrix multiplication as an example in the beginning of article, we only need focus on matrix multiplication itself on mathematics level. But in project, the issue of how to config and use model parallelism or data parallelism can be easily done in OneFlow. OneFlow will handle **The data division in data parallelism**, **model division in model parallelism** and **serial logic** issue quickly and efficiently. 
 
-In consistent view of OneFlow, we can choose either model parallelism or data parallelism or hybrid parallelism freely. 
+In consistent view of OneFlow, we can choose model parallelism, data parallelism, or hybrid parallelism freely. 
 
 ### Code Example
-In the following code, we use consistent view and use two devices to train. The default parallelism method is **data parallelism** in consistent view. The issue of how to set **model parallelism** and **hybrid parallelism** in consistent view will not be discussed in this section. We have special introduction of that in [parallels features of OneFlow](model_mixed_parallel.md).
+In the following code, we use consistent view and use two devices to train. The default parallelism method is **data parallelism** in consistent view. The issue of how to set **model parallelism** and **hybrid parallelism** in consistent view will be discussed in [parallels features of OneFlow](model_mixed_parallel.md).
 
 Complete code: [consistent_strategy.py](../code/extended_topics/consistent_strategy.py)
 
@@ -306,7 +306,7 @@ def train_job(
 ) -> tp.Numpy:
 ```
 
-* The job function is called directly to obtain the training results, which have been completed by OneFlow in distributed process of splitting and combining. Under the consistent view, there are few differences between single machine training program and distributed training program. 
+* The job function is called directly to obtain the training results. The splitting and concatenating in the distributed training are completed automatically by OneFlow. In the consistent view, there are few differences between the single-machine training program and the distributed training program.
 ```python
 for i, (images, labels) in enumerate(zip(train_images, train_labels)):
   loss = train_job(images, labels)
@@ -314,8 +314,8 @@ for i, (images, labels) in enumerate(zip(train_images, train_labels)):
       print(loss.mean())
 ```
 
-## More extended
-With the development of machine learning theory and practice, there are many models which is unable to train in single device. There are also more and more models that can not complete the training well only by data parallelism.
+## More extension
+With the development of machine learning theory and practice, there are many models unable to train in a single device or by data parallelism only.
 
 Adopting `consistent` view in OneFlow, the above problems can be solved well through free selection and combination of parallel methods. We will introduce in [parallel features of OneFlow](model_mixed_parallel.md).
 


### PR DESCRIPTION
> The reason why consistent view is the main feature of OneFlow is that in OneFlow design, if we use `consistent_view`, the op and blob can **get consistently in logic level** from user's point of view. We use matrix multiplication as an example in the beginning of article, we only need focus on matrix multiplication itself on mathematics level. But in project, the issue of how to config and use model parallelism or data parallelism can be easily done in OneFlow. OneFlow will handle **The data division in data parallelism**, **model division in model parallelism** and **serial logic** issue quickly and efficiently. 

这段话的中文版本专业术语较多，虽然看出来有很多需要改的地方但不知道该怎么改。