### PR TITLE
typo in docs.

### DIFF
--- a/cn/docs/basics_topics/data_input.md
+++ b/cn/docs/basics_topics/data_input.md
@@ -60,7 +60,7 @@ python feed_numpy.py
   labels_in = np.random.randint(-10, 10, (32, )).astype(np.int32)
 ```
 
-并在调用作业函数是，直接将 NumPy 数据 `images_in` 和 `labels_in` 作为参数传递：
+并在调用作业函数时，直接将 NumPy 数据 `images_in` 和 `labels_in` 作为参数传递：
 ```python
 images, labels = test_job(images_in, labels_in)
 ```

--- a/cn/docs/basics_topics/distributed_train.md
+++ b/cn/docs/basics_topics/distributed_train.md
@@ -119,7 +119,7 @@ def config_distributed():
 
 分布式脚本代码：[distributed_train.py](../code/basics_topics/distributed_train.py)
 
-在 `192.168.1.12` 及 `192.168.1.12` 上 均运行：
+在 `192.168.1.12` 及 `192.168.1.11` 上 均运行：
 ```shell
 wget https://docs.oneflow.org/code/basics_topics/distributed_train.py
 python3 distributed_train.py

--- a/en/docs/basics_topics/distributed_train.md
+++ b/en/docs/basics_topics/distributed_train.md
@@ -116,7 +116,7 @@ Compared with **single machine training program**, the distributed training prog
 
 Distribution script: [distributed_train.py](../code/basics_topics/distributed_train.py)
 
-Running on both `192.168.1.12` and `192.168.1.12`:
+Running on both `192.168.1.12` and `192.168.1.11`:
 
 ```shell
 wget https://docs.oneflow.org/code/basics_topics/distributed_train.py


### PR DESCRIPTION
Correct the typo of IPs for distributed env. Both in "en" and in "cn"  version.