### PR TITLE
fix typos in basics/04_build_network.md

### DIFF
--- a/cn/docs/basics/04_build_network.md
+++ b/cn/docs/basics/04_build_network.md
@@ -168,4 +168,4 @@ class MySeqModel(nn.Module):
         return self.seq(x)
 ```
 
-除了 Sequential 外，还有 `nn.Modulelist` 及 `nn.ModuleDict`，除了会自动注册参数到整个网络外，他们的其它行为类似 Python list、Python dict，只是常用简单的容器，不会自动进行前后层的前向传播，需要自己手工遍历完成各层的计算。
+除了 Sequential 外，还有 `nn.ModuleList` 及 `nn.ModuleDict`，除了会自动注册参数到整个网络外，他们的其它行为类似 Python list、Python dict，只是常用简单的容器，不会自动进行前后层的前向传播，需要自己手工遍历完成各层的计算。

--- a/en/docs/basics/04_build_network.md
+++ b/en/docs/basics/04_build_network.md
@@ -169,4 +169,4 @@ class MySeqModel(nn.Module):
         return self.seq(x)
 ```
 
-Besides Sequential, there are `nn.Modulelist` and `nn.ModuleDict`. They can automatically register parameters to the whole network. But their other behavior is similar to Python list and Python dict, which are just simple containers and do not automatically propagate forward. You need manually traverse to complete the calculation of each layer.
+Besides Sequential, there are `nn.ModuleList` and `nn.ModuleDict`. They can automatically register parameters to the whole network. But their other behavior is similar to Python list and Python dict, which are just simple containers and do not automatically propagate forward. You need manually traverse to complete the calculation of each layer.


### PR DESCRIPTION
修正中/英文文档基础专题中的"搭建神经网络"最后一段第一行的typo：`nn.Modulelist` -> `nn.ModuleList`