### PR TITLE
fix en typos in global tensor article

### DIFF
--- a/en/docs/parallelism/03_consistent_tensor.md
+++ b/en/docs/parallelism/03_consistent_tensor.md
@@ -35,7 +35,6 @@ In each of the two consoles, import `oneflow` and create `x`.
 === "Terminal 0"
     ```python
     import oneflow as flow
-    ```
 
     placement = flow.placement("cuda",{0:[0,1]})
     sbp = flow.sbp.split(0)

--- a/en/docs/parallelism/03_consistent_tensor.md
+++ b/en/docs/parallelism/03_consistent_tensor.md
@@ -96,7 +96,6 @@ The reason for this transformation lies in that by setting the sbp with `sbp=flo
 === "Terminal 0"
     ```python
     import oneflow as flow
-    ```
 
     x = flow.randn(2,5)
     placement = flow.placement("cuda",{0:[0,1]})


### PR DESCRIPTION
修复英文版文章中的一个格式错误（ https://docs.oneflow.org/en/master/parallelism/03_consistent_tensor.html )

现有问题的格式：

![image](https://user-images.githubusercontent.com/3351623/153990868-1878b7bb-76e2-4807-9298-ead9f88c0f7e.png)

修正过后的格式：

<img width="721" alt="截屏2022-02-15 下午1 20 25" src="https://user-images.githubusercontent.com/69283456/153997611-eddfb989-2ca0-4bc2-a472-5ee52b73abe0.png">

现有问题的格式：

<img width="732" alt="截屏2022-02-15 下午1 24 21" src="https://user-images.githubusercontent.com/69283456/153997953-ecd07db3-ce64-4390-ba72-fa16ac05e157.png">



