### PR TITLE
更新 Tutorial 中 graph 的 save & load

### DIFF
--- a/cn/docs/basics/08_nn_graph.md
+++ b/cn/docs/basics/08_nn_graph.md
@@ -361,29 +361,7 @@ OneFlow 在编译生成计算图的过程中会打印调试信息，比如，将
 
 ### Graph 的保存与加载模型参数
 
-Graph 复用了 Module 的网络参数，可以复用 Module 的 `save` 与 `load` 接口。可以参考 [模型的保存与加载](./07_model_load_save.md) 。
-
-如以上的 `graph_mobile_net_v2`，若想保存它的训练后的模型参数，其实应该保存它其中的 Module（即之前 `model = flowvision.models.mobilenet_v2().to(DEVICE)` 得到的 `model`。
-
-```python
-flow.save(model.state_dict(), "./graph_model")
-```
-
-!!! Note
-    **不能** 用以下方式保存。因为 Graph 在初始化时，会对成员做处理，所以 `graph_mobile_net_v2.model` 其实已经不再是 Module 类型：
-
-    ```python
-    flow.save(graph_mobile_net_v2.model.state_dict(), "./graph_model")  # 会报错
-    ```
-
-加载之前保存好的模型，也是 Module 的工作：
-
-```python
-model = flowvision.models.mobilenet_v2().to(DEVICE)
-model.classifer = nn.Sequential(nn.Dropout(0.2), nn.Linear(model.last_channel, 10))
-model.load_state_dict(flow.load("./graph_model")) # 加载保存好的模型
-# ...
-```
+【待更新】
 
 ### Graph 与部署
 

--- a/cn/docs/basics/08_nn_graph.md
+++ b/cn/docs/basics/08_nn_graph.md
@@ -38,6 +38,7 @@ OneFlow 默认以 Eager 模式运行。
 
     model = flowvision.models.mobilenet_v2().to(DEVICE)
     model.classifer = nn.Sequential(nn.Dropout(0.2), nn.Linear(model.last_channel, 10))
+    model.train()
 
     loss_fn = nn.CrossEntropyLoss().to(DEVICE)
     optimizer = flow.optim.SGD(model.parameters(), lr=1e-3)
@@ -191,11 +192,12 @@ y_pred = graph_mobile_net_v2(x)
     )
 
     train_dataloader = flow.utils.data.DataLoader(
-        training_data, BATCH_SIZE, shuffle=True
+        training_data, BATCH_SIZE, shuffle=True, drop_last=True
     )
 
     model = flowvision.models.mobilenet_v2().to(DEVICE)
     model.classifer = nn.Sequential(nn.Dropout(0.2), nn.Linear(model.last_channel, 10))
+    model.train()
 
     loss_fn = nn.CrossEntropyLoss().to(DEVICE)
     optimizer = flow.optim.SGD(model.parameters(), lr=1e-3)
@@ -359,13 +361,41 @@ OneFlow 在编译生成计算图的过程中会打印调试信息，比如，将
 
 除了以上介绍的方法外，训练过程中获取参数的梯度、获取 learning rate 等功能，也正在开发中，即将上线。
 
-### Graph 的保存与加载模型参数
+### Graph 模型的保存与加载
 
-【待更新】
+在训练 Graph 模型时，常常需要将已经训练了一段时间的模型的参数以及其他诸如优化器参数等状态进行保存，方便中断后恢复训练。
+
+Graph 模型对象具有和 Module 类似的 `state_dict` 和 `load_state_dict` 接口，配合 [save](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.save#oneflow.save) 和 [load](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.load#oneflow.load) 就可以实现保存与加载 Graph 模型。这与之前在 [模型的保存与加载](../basics/07_model_load_save.md) 中介绍的 Eager 模式下是类似的。和 Eager 略有不同的是，在训练过程中调用 Graph 的 `state_dict` 时，除了会得到内部 Module 各层的参数，也会得到训练迭代数、优化器参数等其他状态，以便之后恢复训练。
+
+例如，希望在以上训练 `graph_mobile_net_v2` 的过程中，每经过 1 个 epoch 将模型最新的状态保存一次，那么可以添加以下代码：
+
+假设我们想要保存在当前目录下的 "GraphMobileNetV2" 中：
+```python
+CHECKPOINT_SAVE_DIR = "./GraphMobileNetV2"
+```
+在每个 epoch 训练完成处插入以下代码：
+```python
+shutil.rmtree(CHECKPOINT_SAVE_DIR)  # 清理上一次的状态
+flow.save(graph_mobile_net_v2.state_dict(), CHECKPOINT_SAVE_DIR)
+```
+
+!!! Note
+    **不能** 用以下方式保存。因为 Graph 在初始化时，会对成员做处理，所以 `graph_mobile_net_v2.model` 其实已经不再是 Module 类型：
+
+    ```python
+    flow.save(graph_mobile_net_v2.model.state_dict(), CHECKPOINT_SAVE_DIR)  # 会报错
+    ```
+
+当需要恢复之前保存的状态时：
+```python
+state_dict = flow.load(CHECKPOINT_SAVE_DIR)
+graph_mobile_net_v2.load_state_dict(state_dict)
+```
+
 
 ### Graph 与部署
 
-nn.Graph 支持保存计算图和模型参数，可以很方便的支持模型部署。
+nn.Graph 支持同时保存模型参数和计算图，可以很方便的支持模型部署。
 
 如果有模型部署的需求，那么应该通过 `oneflow.save` 接口，将 `Graph` 对象导出为部署需要的格式：
 
@@ -374,12 +404,7 @@ flow.save(graph_mobile_net_v2, "./1/model")
 ```
 
 !!! Note
-    注意和上一节保存模型参数的区别。上一节中保存模型参数会报错，是因为 Graph 初始化对 model 成员进行了处理。这一节中调用 `save` 接口没有问题，`save` 接口直接支持保存 Graph 对象，既保存模型参数，又保存模型结构。
-
-    ```python
-    flow.save(graph_mobile_net_v2.model.state_dict(), "./graph_model")  # 会报错
-    flow.save(graph_mobile_net_v2, "./1/model")
-    ```
+    注意和上一节的区别。 `save` 接口既支持保存 state_dict，也支持保存 Graph 对象。当保存 Graph 对象时，模型参数和计算图将被同时保存，以与模型结构定义代码解耦。
 
 这样，`./1/model` 目录下会同时保存部署所需的模型参数和计算图。详细的部署流程可以参阅 [模型部署](../cookies/serving.md) 一文。
 


### PR DESCRIPTION
Issue: https://github.com/Oneflow-Inc/oneflow-documentation/issues/424
中文版预览：https://alive1024.github.io/oneflow-documentation/master/basics/08_nn_graph.html#graph_4
英文版预览：https://alive1024.github.io/oneflow-documentation/en/master/basics/08_nn_graph.html#save-and-load-graph-models

### 内容摘要 & 疑问：
目前的情况是 graph 新增了 state_dict 和 load_state_dict 两个方法，有问题之处已使用 _**粗斜体 (?)**_  的形式标记

假设现有继承了 nn.Graph 的子类 MyGraph 及其对象 graph。



_**可以分为两种方式(?)**_ 

#### 1. 只保存模型参数
- 保存：`flow.save(graph.state_dict(), './model_state_dict')`
- 加载：`graph.load_state_dict(flow.load('./model_state_dict'))`

state_dict 方法将在 MyGraph 的 `__init__` 方法中的创建的属性的名称作为返回的 OrderedDict 的 keys。
假设在 `__init__` 方法中通过 `add_optimzier` 方法添加了 optimzier， 但是调用 state_dict 得到的 OrderedDict _**并没有关于 optimzier 的状态 (?)**_ 

#### 2. 保存整个模型
- 保存：`flow.save(graph, './model')`
- 加载：`graph = flow.load('./model')`  【原教程中原有内容未涉及】

使用 flow.save 前要使得 graph 模型已被编译，可以通过 `_compile` 方法或者构造任意数据进行一次前向传播。否则会报错：RuntimeError: graph must be compiled first. （`_compile` 方法貌似算是 private 的， _**是否不应该提及这种方式 (?)**_ ）

实际使用 load 时报错 ：
```
Traceback (most recent call last):
  File "temp.py", line 71, in <module>
    load_obj()
  File "temp.py", line 64, in load_obj
    flow.load("./model")
  File "/usr/local/miniconda3/lib/python3.7/site-packages/oneflow/framework/check_point_v2.py", line 310, in load
    return legacy_load(path, global_src_rank)
  File "/usr/local/miniconda3/lib/python3.7/site-packages/oneflow/framework/check_point_v2.py", line 253, in legacy_load
    assert SNAPSHOT_DONE_FILENAME in all_files
AssertionError
```
直接原因是 **_缺失名为 `snapshot_done` 的标志文件 (?)_**