### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ mkdocs==1.2.2
 mkdocs-material==7.1.11
 mkdocs-material-extensions==1.0.1
 mike==1.0.1
+Jinja2==3.0.2


### PR DESCRIPTION
Jinja2 > 3.1 的时候，会不兼容。
应该雨 Jinja2 改了接口有关。在这里限定下版本。