### PR TITLE
修复 nn_graph_code 英文文档中的错误。

### DIFF
--- a/cn/docs/basics/08_nn_graph.md
+++ b/cn/docs/basics/08_nn_graph.md
@@ -31,7 +31,6 @@ OneFlow 默认以 Eager 模式运行。
         transform=transforms.ToTensor(),
         download=True,
         source_url="https://oneflow-public.oss-cn-beijing.aliyuncs.com/datasets/cifar/cifar-10-python.tar.gz",
-
     )
 
     train_dataloader = flow.utils.data.DataLoader(


### PR DESCRIPTION
修复了 [Static Graph Interface](https://docs.oneflow.org/en/master/basics/08_nn_graph.html) 中代码无法运行的问题，与中文文档中的[改动](https://github.com/Oneflow-Inc/oneflow-documentation/pull/459/files)一致。