### PR TITLE
Fix Code Error in Transfer Learning Tutorial

### DIFF
--- a/cn/docs/cookies/transfer_learning.md
+++ b/cn/docs/cookies/transfer_learning.md
@@ -81,6 +81,10 @@ model = resnet18(pretrained=True)
 model.fc = nn.Linear(model.fc.in_features, 10)
 ```
 
+然后将模型加载到计算设备：
+```python
+model = model.to(DEVICE)
+```
 
 ### 训练模型
 

--- a/en/docs/cookies/transfer_learning.md
+++ b/en/docs/cookies/transfer_learning.md
@@ -80,6 +80,10 @@ Here, we get the ResNet-18 model loaded with pretrained weights by setting the `
 model.fc = nn.Linear(model.fc.in_features, 10)
 ```
 
+And load the model to the computing device:
+```python
+model = model.to(DEVICE)
+```
 
 ### Train the Model
 


### PR DESCRIPTION
之前写教程时漏掉了 `model = model.to(DEVICE)` 这行代码，中英文版已同步修复。