### PR TITLE
redirects global_tensor to consistent_tensor

### DIFF
--- a/cn/mkdocs.yml
+++ b/cn/mkdocs.yml
@@ -47,6 +47,10 @@ theme:
 # Plugins
 plugins:
   - search
+  - redirects:
+      redirect_maps:
+          'parallelism/03_global_tensor.md': 'parallelism/03_consistent_tensor.md'
+
 extra:
   version:
     provider: mike

--- a/en/mkdocs.yml
+++ b/en/mkdocs.yml
@@ -47,6 +47,10 @@ theme:
 # Plugins
 plugins:
   - search
+  - redirects:
+      redirect_maps:
+          'parallelism/03_global_tensor.md': 'parallelism/03_consistent_tensor.md'
+
 extra:
   version:
     provider: mike

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ mkdocs-material==7.1.11
 mkdocs-material-extensions==1.0.1
 mike==1.0.1
 Jinja2==3.0.2
+mkdocs-redirects==1.0.4


### PR DESCRIPTION
添加 mkdocs_redirects 插件，把 URL 里的 gloabal_tensor.html 重定向到 consistent_tensor.html

需求来自：https://github.com/Oneflow-Inc/oneflow/pull/8505#discussion_r915427663