### PR TITLE
refine API

### DIFF
--- a/cn/docs/basics/01_quickstart.md
+++ b/cn/docs/basics/01_quickstart.md
@@ -58,7 +58,7 @@ Extracting data/FashionMNIST/raw/train-images-idx3-ubyte.gz to data/FashionMNIST
 
 数据集下载并解压到 `./data` 目录下。
 
-利用 [oneflow.utils.data.DataLoader](https://oneflow.readthedocs.io/en/master/utils.html#oneflow.utils.data.DataLoader) 可以将 `dataset` 封装为迭代器，方便后续训练。
+利用 [oneflow.utils.data.DataLoader](https://oneflow.readthedocs.io/en/v0.8.1/utils.data.html?highlight=oneflow.utils.data.DataLoader#oneflow.utils.data.DataLoader) 可以将 `dataset` 封装为迭代器，方便后续训练。
 
 ```python
 train_dataloader = flow.utils.data.DataLoader(

--- a/cn/docs/basics/01_quickstart.md
+++ b/cn/docs/basics/01_quickstart.md
@@ -128,7 +128,7 @@ NeuralNetwork(
 
 ## 训练模型
 
-为了训练模型，我们需要损失函数 `loss_fn` 和优化器 `optimizer`，损失函数用于评价神经网络预测的结果与 label 的差距；`optimizer` 调整网络的参数，使得网络预测的结果越来越接近 label（标准答案），这里选用 [oneflow.optim.SGD](https://oneflow.readthedocs.io/en/master/optim.html?highlight=optim.SGD#oneflow.optim.SGD)。这一过程被称为反向传播。
+为了训练模型，我们需要损失函数 `loss_fn` 和优化器 `optimizer`，损失函数用于评价神经网络预测的结果与 label 的差距；`optimizer` 调整网络的参数，使得网络预测的结果越来越接近 label（标准答案），这里选用 [oneflow.optim.SGD](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.optim.SGD.html)。这一过程被称为反向传播。
 
 ```python
 loss_fn = nn.CrossEntropyLoss().to(DEVICE)
@@ -223,7 +223,7 @@ loss: 1.835239  [12800/60000]
 
 ## 保存与加载模型
 
-调用 [oneflow.save](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.save#oneflow.save) 可以保存模型。保存的模型可以通过 [oneflow.load](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.load#oneflow.load) 加载，用于预测等工作。
+调用 [oneflow.save](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.save.html) 可以保存模型。保存的模型可以通过 [oneflow.load](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.load.html) 加载，用于预测等工作。
 
 ```python
 flow.save(model.state_dict(), "./model")

--- a/cn/docs/basics/02_tensor.md
+++ b/cn/docs/basics/02_tensor.md
@@ -57,7 +57,7 @@ tensor([[0.6213, 0.6142, 0.1592],
 
 ### 通过算子创建
 
-OneFlow 中还提供了一些算子，可以通过它们创建 Tensor。比如 [ones](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.ones#oneflow.ones)、 [zeros](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.zeros#oneflow.zeros),、[eye](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.eye#oneflow.eye)，它们分别创建全为1的张量、全为0的张量和单位张量。
+OneFlow 中还提供了一些算子，可以通过它们创建 Tensor。比如 [ones](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.ones.html)、 [zeros](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.zeros.html)、[eye](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.eye.html)，它们分别创建全为1的张量、全为0的张量和单位张量。
 
 ```python
 x5 = flow.ones(2, 3)
@@ -78,7 +78,7 @@ tensor([[1., 0., 0.],
         [0., 0., 1.]], dtype=oneflow.float32)
 ```
 
-[randn](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.randn#oneflow.randn) 方法可以创建随机化的张量：
+[randn](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.randn.html) 方法可以创建随机化的张量：
 
 ```python
 x8 = flow.randn(2,3)
@@ -86,7 +86,7 @@ x8 = flow.randn(2,3)
 
 ## `Tensor` 与 `tensor` 的区别
 
-细心的用户会发现，OneFlow 中有 [oneflow.Tensor](https://oneflow.readthedocs.io/en/master/tensor.html?highlight=oneflow.Tensor#oneflow.Tensor) 和 [oneflow.tensor](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.Tensor#oneflow.tensor) 两个接口，它们都能用来创建张量。那么它们有什么区别呢？
+细心的用户会发现，OneFlow 中有 [oneflow.Tensor](https://oneflow.readthedocs.io/en/v0.8.1/tensor.html) 和 [oneflow.tensor](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.tensor.html) 两个接口，它们都能用来创建张量。那么它们有什么区别呢？
 
 简单而言，大写的 `Tensor` 数据类型默认限定为 `float32`，而小写的 `tensor` 的数据类型可以随着创建时的数据改变。以下代码展示了两者这方面的区别：
 
@@ -136,7 +136,7 @@ oneflow.float32
 cpu:0
 ```
 
-可以通过 [reshape](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.reshape#oneflow.reshape) 方法改变 Tensor 的形状，用 [to](https://oneflow.readthedocs.io/en/master/tensor.html?highlight=Tensor.to#oneflow.Tensor.to) 方法改变 Tensor 的数据类型和所处设备：
+可以通过 [reshape](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.reshape.html) 方法改变 Tensor 的形状，用 [Tensor.to](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.Tensor.to.html) 方法改变 Tensor 的数据类型和所处设备：
 
 ```
 x10 = x9.reshape(2, 2)
@@ -152,7 +152,7 @@ oneflow.int32 cuda:0
 
 ## 操作 Tensor 的常见算子
 
-OneFlow 中提供了大量的算子，对 Tensor 进行操作，它们大多在 [oneflow](https://oneflow.readthedocs.io/en/master/oneflow.html)、[oneflow.Tensor](https://oneflow.readthedocs.io/en/master/tensor.html)、[oneflow.nn](https://oneflow.readthedocs.io/en/master/nn.html)、[oneflow.nn.functional](https://oneflow.readthedocs.io/en/v0.8.1/nn.functional.html)这几个名称空间下。
+OneFlow 中提供了大量的算子，对 Tensor 进行操作，它们大多在 [oneflow](https://oneflow.readthedocs.io/en/v0.8.1/oneflow.html)、[oneflow.Tensor](https://oneflow.readthedocs.io/en/v0.8.1/tensor.html)、[oneflow.nn](https://oneflow.readthedocs.io/en/v0.8.1/nn.html)、[oneflow.nn.functional](https://oneflow.readthedocs.io/en/v0.8.1/nn.functional.html)这几个名称空间下。
 
 OneFlow 中的 Tensor，与 Numpy 数组一样易用。比如，支持与 Numpy 类似的切片操作：
 
@@ -175,4 +175,4 @@ tensor([[1., 0., 1., 1.],
         [1., 0., 1., 1.]], dtype=oneflow.float32)
 ```
 
-此外，OneFlow 中还有很多其它操作，如算数相关操作的 [add](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.add#oneflow.add)、[sub](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.sub#oneflow.sub)、[mul](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.mul#oneflow.mul)、[div](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.div#oneflow.div)等；位置相关操作的 [scatter](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.scatter#oneflow.scatter)、[gather](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.gather#oneflow.gather)、[gather_nd](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.gather_nd#oneflow.gather_nd)等；以及激活函数、卷积等（[relu](https://oneflow.readthedocs.io/en/master/functional.html?highlight=oneflow.relu#oneflow.nn.functional.relu)、[conv2d](https://oneflow.readthedocs.io/en/master/functional.html?highlight=oneflow.conv2d#oneflow.nn.functional.conv2d)），点击它们的链接可以查看更详细的 API 说明，并找到更多的其它算子。
+此外，OneFlow 中还有很多其它操作，如算数相关操作的 [add](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.add.html)、[sub](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.sub.html)、[mul](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.mul.html)、[div](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.div.html)等；位置相关操作的 [scatter](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.scatter.html)、[gather](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.gather.html) 等；以及激活函数、卷积等（[relu](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.functional.relu.html)、[conv2d](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.functional.conv2d.html)），点击它们的链接可以查看更详细的 API 说明，并找到更多的其它算子。

--- a/cn/docs/basics/02_tensor.md
+++ b/cn/docs/basics/02_tensor.md
@@ -152,7 +152,7 @@ oneflow.int32 cuda:0
 
 ## 操作 Tensor 的常见算子
 
-OneFlow 中提供了大量的算子，对 Tensor 进行操作，它们大多在 [oneflow](https://oneflow.readthedocs.io/en/master/oneflow.html)、[oneflow.Tensor](https://oneflow.readthedocs.io/en/master/tensor.html)、[oneflow.nn](https://oneflow.readthedocs.io/en/master/nn.html)、[oneflow.nn.functional](https://oneflow.readthedocs.io/en/master/functional.html)这几个名称空间下。
+OneFlow 中提供了大量的算子，对 Tensor 进行操作，它们大多在 [oneflow](https://oneflow.readthedocs.io/en/master/oneflow.html)、[oneflow.Tensor](https://oneflow.readthedocs.io/en/master/tensor.html)、[oneflow.nn](https://oneflow.readthedocs.io/en/master/nn.html)、[oneflow.nn.functional](https://oneflow.readthedocs.io/en/v0.8.1/nn.functional.html)这几个名称空间下。
 
 OneFlow 中的 Tensor，与 Numpy 数组一样易用。比如，支持与 Numpy 类似的切片操作：
 

--- a/cn/docs/basics/03_dataset_dataloader.md
+++ b/cn/docs/basics/03_dataset_dataloader.md
@@ -104,7 +104,7 @@ plt.show()
 
 ## 自定义 Dataset
 
-通过继承 [oneflow.utils.data.Dataset](https://oneflow.readthedocs.io/en/v0.8.1/utils.data.html?highlight=utils.data.Dataset#oneflow.utils.data.Dataset) 可以实现自定义 `Dataset`，自定义 `Dataset` 同样可以配合下一节介绍的 `Dataloader` 使用，简化数据处理的流程。
+通过继承 [oneflow.utils.data.Dataset](https://oneflow.readthedocs.io/en/v0.8.1/utils.data.html#oneflow.utils.data.Dataset) 可以实现自定义 `Dataset`，自定义 `Dataset` 同样可以配合下一节介绍的 `Dataloader` 使用，简化数据处理的流程。
 
 以下的例子展示了如何实现一个自定义 `Dataset`，它的关键步骤是：
 

--- a/cn/docs/basics/03_dataset_dataloader.md
+++ b/cn/docs/basics/03_dataset_dataloader.md
@@ -104,7 +104,7 @@ plt.show()
 
 ## 自定义 Dataset
 
-通过继承 [oneflow.utils.data.Dataset](https://oneflow.readthedocs.io/en/master/utils.html?highlight=oneflow.utils.data.Dataset#oneflow.utils.data.Dataset) 可以实现自定义 `Dataset`，自定义 `Dataset` 同样可以配合下一节介绍的 `Dataloader` 使用，简化数据处理的流程。
+通过继承 [oneflow.utils.data.Dataset](https://oneflow.readthedocs.io/en/v0.8.1/utils.data.html?highlight=utils.data.Dataset#oneflow.utils.data.Dataset) 可以实现自定义 `Dataset`，自定义 `Dataset` 同样可以配合下一节介绍的 `Dataloader` 使用，简化数据处理的流程。
 
 以下的例子展示了如何实现一个自定义 `Dataset`，它的关键步骤是：
 

--- a/cn/docs/basics/04_build_network.md
+++ b/cn/docs/basics/04_build_network.md
@@ -1,6 +1,6 @@
 # 搭建神经网络
 
-​神经网络的各层，可以使用 [oneflow.nn](https://oneflow.readthedocs.io/en/master/nn.html) 名称空间下的 API 搭建，它提供了构建神经网络所需的常见 Module（如 [oneflow.nn.Conv2d](https://oneflow.readthedocs.io/en/master/nn.html?highlight=oneflow.nn.Conv2D#oneflow.nn.Conv2d)，[oneflow.nn.ReLU](https://oneflow.readthedocs.io/en/master/nn.html?highlight=oneflow.nn.ReLU#oneflow.nn.ReLU) 等等）。 用于搭建网络的所有 Module 类都继承自 [oneflow.nn.Module](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.Module.html?highlight=oneflow.nn.Module#oneflow.nn.Module)，多个简单的 Module 可以组合在一起构成更复杂的 Module，用这种方式，用户可以轻松地搭建和管理复杂的神经网络。
+​神经网络的各层，可以使用 [oneflow.nn](https://oneflow.readthedocs.io/en/v0.8.1/nn.html) 名称空间下的 API 搭建，它提供了构建神经网络所需的常见 Module（如 [oneflow.nn.Conv2d](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.Conv2d.html)，[oneflow.nn.ReLU](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.ReLU.html) 等等）。 用于搭建网络的所有 Module 类都继承自 [oneflow.nn.Module](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.Module.html)，多个简单的 Module 可以组合在一起构成更复杂的 Module，用这种方式，用户可以轻松地搭建和管理复杂的神经网络。
 
 ```python
 import oneflow as flow
@@ -75,7 +75,7 @@ Predicted class: tensor([1], dtype=oneflow.int32)
 
 ## `flow.nn.functional`
 
-除了 `oneflow.nn` 外，[oneflow.nn.functional](https://oneflow.readthedocs.io/en/v0.8.1/nn.functional.html) 名称空间下也提供了不少 API。它与 `oneflow.nn` 在功能上有一定的重叠。比如 [nn.functional.relu](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.functional.relu.html) 与 [nn.ReLU](https://oneflow.readthedocs.io/en/master/nn.html?highlight=relu#oneflow.nn.ReLU) 都可用于神经网络做 activation 操作。
+除了 `oneflow.nn` 外，[oneflow.nn.functional](https://oneflow.readthedocs.io/en/v0.8.1/nn.functional.html) 名称空间下也提供了不少 API。它与 `oneflow.nn` 在功能上有一定的重叠。比如 [nn.functional.relu](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.functional.relu.html) 与 [nn.ReLU](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.ReLU.html) 都可用于神经网络做 activation 操作。
 
 两者的区别主要有：
 
@@ -126,7 +126,7 @@ print(f"Predicted class: {y_pred}")
 
 ## Module 容器
 
-比较以上 `NeuralNetwork` 与 `FunctionalNeuralNetwork` 实现的异同，可以发现 [nn.Sequential](https://oneflow.readthedocs.io/en/master/nn.html?highlight=nn.Sequential#oneflow.nn.Sequential) 对于简化代码起到了重要作用。
+比较以上 `NeuralNetwork` 与 `FunctionalNeuralNetwork` 实现的异同，可以发现 [nn.Sequential](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.Sequential.html) 对于简化代码起到了重要作用。
 
 `nn.Sequential` 是一种特殊容器，只要是继承自 `nn.Module` 的类都可以放置放置到其中。
 

--- a/cn/docs/basics/04_build_network.md
+++ b/cn/docs/basics/04_build_network.md
@@ -1,6 +1,6 @@
 # 搭建神经网络
 
-​神经网络的各层，可以使用 [oneflow.nn](https://oneflow.readthedocs.io/en/master/nn.html) 名称空间下的 API 搭建，它提供了构建神经网络所需的常见 Module（如 [oneflow.nn.Conv2d](https://oneflow.readthedocs.io/en/master/nn.html?highlight=oneflow.nn.Conv2D#oneflow.nn.Conv2d)，[oneflow.nn.ReLU](https://oneflow.readthedocs.io/en/master/nn.html?highlight=oneflow.nn.ReLU#oneflow.nn.ReLU) 等等）。 用于搭建网络的所有 Module 类都继承自 [oneflow.nn.Module](https://oneflow.readthedocs.io/en/master/module.html#oneflow.nn.Module)，多个简单的 Module 可以组合在一起构成更复杂的 Module，用这种方式，用户可以轻松地搭建和管理复杂的神经网络。
+​神经网络的各层，可以使用 [oneflow.nn](https://oneflow.readthedocs.io/en/master/nn.html) 名称空间下的 API 搭建，它提供了构建神经网络所需的常见 Module（如 [oneflow.nn.Conv2d](https://oneflow.readthedocs.io/en/master/nn.html?highlight=oneflow.nn.Conv2D#oneflow.nn.Conv2d)，[oneflow.nn.ReLU](https://oneflow.readthedocs.io/en/master/nn.html?highlight=oneflow.nn.ReLU#oneflow.nn.ReLU) 等等）。 用于搭建网络的所有 Module 类都继承自 [oneflow.nn.Module](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.Module.html?highlight=oneflow.nn.Module#oneflow.nn.Module)，多个简单的 Module 可以组合在一起构成更复杂的 Module，用这种方式，用户可以轻松地搭建和管理复杂的神经网络。
 
 ```python
 import oneflow as flow
@@ -75,7 +75,7 @@ Predicted class: tensor([1], dtype=oneflow.int32)
 
 ## `flow.nn.functional`
 
-除了 `oneflow.nn` 外，[oneflow.nn.functional](https://oneflow.readthedocs.io/en/master/functional.html) 名称空间下也提供了不少 API。它与 `oneflow.nn` 在功能上有一定的重叠。比如 [nn.functional.relu](https://oneflow.readthedocs.io/en/master/functional.html?highlight=relu#oneflow.nn.functional.relu) 与 [nn.ReLU](https://oneflow.readthedocs.io/en/master/nn.html?highlight=relu#oneflow.nn.ReLU) 都可用于神经网络做 activation 操作。
+除了 `oneflow.nn` 外，[oneflow.nn.functional](https://oneflow.readthedocs.io/en/v0.8.1/nn.functional.html) 名称空间下也提供了不少 API。它与 `oneflow.nn` 在功能上有一定的重叠。比如 [nn.functional.relu](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.functional.relu.html) 与 [nn.ReLU](https://oneflow.readthedocs.io/en/master/nn.html?highlight=relu#oneflow.nn.ReLU) 都可用于神经网络做 activation 操作。
 
 两者的区别主要有：
 

--- a/cn/docs/basics/05_autograd.md
+++ b/cn/docs/basics/05_autograd.md
@@ -139,7 +139,7 @@ tensor(20., dtype=oneflow.float32)
 ### 不记录某个 Tensor 的梯度
 
 默认情况下，OneFlow 会 tracing `requires_grad` 为 `True` 的 Tensor，自动求梯度。
-不过有些情况可能并不需要 OneFlow 这样做，比如只是想试一试前向推理。那么可以使用 [oneflow.no_grad](https://oneflow.readthedocs.io/en/master/oneflow.html#oneflow.no_grad) 或 [oneflow.Tensor.detach](https://oneflow.readthedocs.io/en/master/tensor.html#oneflow.Tensor.detach) 方法设置。
+不过有些情况可能并不需要 OneFlow 这样做，比如只是想试一试前向推理。那么可以使用 [oneflow.no_grad](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.no_grad.html) 或 [oneflow.Tensor.detach](https://oneflow.readthedocs.io/en/master/generated/oneflow.Tensor.detach.html#oneflow.Tensor.detach) 方法设置。
 
 ```python
 z = flow.matmul(x, w)+b

--- a/cn/docs/basics/06_optimization.md
+++ b/cn/docs/basics/06_optimization.md
@@ -2,7 +2,7 @@
 
 到目前为止，我们已经掌握如何使用 OneFlow [加载数据](./03_dataset_dataloader.md)、[搭建模型](./04_build_network.md)、[自动计算模型参数的梯度](./05_autograd.md)，将它们组合在一起，我们就可以利用反向传播算法训练模型。
 
-在 [oneflow.optim](https://oneflow.readthedocs.io/en/master/optim.html) 中，有各类 `optimizer`，它们可以简化实现反向传播的代码。
+在 [oneflow.optim](https://oneflow.readthedocs.io/en/v0.8.1/optim.html) 中，有各类 `optimizer`，它们可以简化实现反向传播的代码。
 
 本文将先介绍反向传播的基本概念，再介绍如何使用 `oneflow.optim` 类。
 
@@ -123,7 +123,7 @@ model = MyLrModule(0.01, 500)
 
 ### loss 函数
 
-然后，选择好 loss 函数，OneFlow 自带了多种 loss 函数，我们在这里选择 [MSELoss](https://oneflow.readthedocs.io/en/master/nn.html?highlight=mseloss#oneflow.nn.MSELoss)：
+然后，选择好 loss 函数，OneFlow 自带了多种 loss 函数，我们在这里选择 [MSELoss](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.MSELoss.html)：
 
 ```python
 loss = flow.nn.MSELoss(reduction="sum")
@@ -131,7 +131,7 @@ loss = flow.nn.MSELoss(reduction="sum")
 
 ### 构造 optimizer
 
-反向传播的逻辑，都被封装在 optimizer 中。我们在此选择 [SGD](https://oneflow.readthedocs.io/en/master/optim.html?highlight=sgd#oneflow.optim.SGD)，你可以根据需要选择其它的优化算法，如 [Adam](https://oneflow.readthedocs.io/en/master/optim.html?highlight=adam#oneflow.optim.Adam)、[AdamW](https://oneflow.readthedocs.io/en/master/optim.html?highlight=adamw#oneflow.optim.AdamW) 等。
+反向传播的逻辑，都被封装在 optimizer 中。我们在此选择 [SGD](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.optim.SGD.html)，你可以根据需要选择其它的优化算法，如 [Adam](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.optim.Adam.html)、[AdamW](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.optim.AdamW.html) 等。
 
 ```python
 optimizer = flow.optim.SGD(model.parameters(), model.lr)

--- a/cn/docs/basics/07_model_load_save.md
+++ b/cn/docs/basics/07_model_load_save.md
@@ -5,7 +5,7 @@
 - 将已经训练一段时间的模型保存，方便下次继续训练
 - 将训练好的模型保存，方便后续直接用于预测
 
-在本文中，我们将介绍，如何使用 [save](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.save#oneflow.save) 和 [load](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.load#oneflow.load) API 保存模型、加载模型。
+在本文中，我们将介绍，如何使用 [save](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.save.html) 和 [load](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.load.html) API 保存模型、加载模型。
 
 同时也会展示，如何加载预训练模型，完成预测任务。
 
@@ -51,7 +51,7 @@ OrderedDict([('weight',
 
 ## 模型保存
 
-我们可以使用 [oneflow.save](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.save#oneflow.save)方法保存模型。
+我们可以使用 [oneflow.save](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.save.html)方法保存模型。
 
 ```python
 flow.save(m.state_dict(), "./model")
@@ -61,7 +61,7 @@ flow.save(m.state_dict(), "./model")
 
 ## 模型加载
 
-使用 [oneflow.load](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.load#oneflow.load) 可以将参数从指定的磁盘路径加载参数到内存，得到存有参数的字典。
+使用 [oneflow.load](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.load.html) 可以将参数从指定的磁盘路径加载参数到内存，得到存有参数的字典。
 
 ```python
 params = flow.load("./model")

--- a/cn/docs/basics/07_model_load_save.md
+++ b/cn/docs/basics/07_model_load_save.md
@@ -51,7 +51,7 @@ OrderedDict([('weight',
 
 ## 模型保存
 
-我们可以使用 [oneflow.save](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.save.html)方法保存模型。
+我们可以使用 [oneflow.save](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.save.html) 方法保存模型。
 
 ```python
 flow.save(m.state_dict(), "./model")

--- a/cn/docs/basics/08_nn_graph.md
+++ b/cn/docs/basics/08_nn_graph.md
@@ -4,7 +4,7 @@
 
 这两种方式各有优缺点，OneFlow 对两种方式均提供了支持，默认情况下是 Eager 模式。如果你是按顺序阅读本基础专题的教程，那么，到目前为止所接触的所有代码都是 Eager 模式的代码。
 
-一般而言，动态图更易用，静态图性能更具优势。OneFlow 提供的 [nn.Graph](https://oneflow.readthedocs.io/en/master/graph.html) 模块，让用户可以用类似 Eager 的编程习惯，构建静态图并训练模型。
+一般而言，动态图更易用，静态图性能更具优势。OneFlow 提供的 [nn.Graph](https://oneflow.readthedocs.io/en/v0.8.1/graph.html) 模块，让用户可以用类似 Eager 的编程习惯，构建静态图并训练模型。
 
 ## OneFlow 的 Eager 模式
 
@@ -80,7 +80,7 @@ loss: 6.644351  [  960/50000]
 
 ### 自定义一个 Graph
 
-OneFlow 提供了 [nn.Graph](https://oneflow.readthedocs.io/en/master/graph.html) 基类。用户可以通过继承它，自定义 Graph 类。
+OneFlow 提供了 [nn.Graph](https://oneflow.readthedocs.io/en/v0.8.1/graph.html) 基类。用户可以通过继承它，自定义 Graph 类。
 
 ```python
 import oneflow as flow
@@ -366,7 +366,7 @@ OneFlow 在编译生成计算图的过程中会打印调试信息，比如，将
 
 在训练 Graph 模型时，常常需要将已经训练了一段时间的模型的参数以及其他诸如优化器参数等状态进行保存，方便中断后恢复训练。
 
-Graph 模型对象具有和 Module 类似的 `state_dict` 和 `load_state_dict` 接口，配合 [save](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.save#oneflow.save) 和 [load](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.load#oneflow.load) 就可以实现保存与加载 Graph 模型。这与之前在 [模型的保存与加载](../basics/07_model_load_save.md) 中介绍的 Eager 模式下是类似的。和 Eager 略有不同的是，在训练过程中调用 Graph 的 `state_dict` 时，除了会得到内部 Module 各层的参数，也会得到训练迭代数、优化器参数等其他状态，以便之后恢复训练。
+Graph 模型对象具有和 Module 类似的 `state_dict` 和 `load_state_dict` 接口，配合 [save](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.save.html) 和 [load](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.load.html) 就可以实现保存与加载 Graph 模型。这与之前在 [模型的保存与加载](../basics/07_model_load_save.md) 中介绍的 Eager 模式下是类似的。和 Eager 略有不同的是，在训练过程中调用 Graph 的 `state_dict` 时，除了会得到内部 Module 各层的参数，也会得到训练迭代数、优化器参数等其他状态，以便之后恢复训练。
 
 例如，希望在以上训练 `graph_mobile_net_v2` 的过程中，每经过 1 个 epoch 将模型最新的状态保存一次，那么可以添加以下代码：
 

--- a/cn/docs/basics/08_nn_graph.md
+++ b/cn/docs/basics/08_nn_graph.md
@@ -320,7 +320,7 @@ print(graph_mobile_net_v2)
     ...
 ```
 
-**第二种** 方式是调用 Graph 对象的 [debug](https://start.oneflow.org/oneflow-api-cn/graph.html#oneflow.nn.Graph.debug) 方法，就开启了 Graph 的调试模式。
+**第二种** 方式是调用 Graph 对象的 [debug](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.Graph.debug.html) 方法，就开启了 Graph 的调试模式。
 
 ```python
 graph_mobile_net_v2.debug(v_level=1) # v_level 参数默认值为 0

--- a/cn/docs/cookies/global_tensor.md
+++ b/cn/docs/cookies/global_tensor.md
@@ -104,7 +104,7 @@ Global data of global tensor:
 
 ## 由 Local Tensor 得到 Global Tensor
 
-可以先创建 Local Tensor，再利用 [Tensor.to_global](https://oneflow.readthedocs.io/en/master/tensor.html#oneflow.Tensor.to_global) 方法，将 Local Tensor 转为 Global Tensor。
+可以先创建 Local Tensor，再利用 [Tensor.to_global](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.Tensor.to_global.html) 方法，将 Local Tensor 转为 Global Tensor。
 
 创建如下程序，采用上文同样的方式启动：
 
@@ -136,7 +136,7 @@ Global Tensor 除了 shape，还有数据部分。一个 Global Tensor 的内部
 
 ## 由 Global Tensor 得到 Local Tensor
 
-如果想得到 Global Tensor 的本地分量，可以通过 [to_local](https://oneflow.readthedocs.io/en/master/tensor.html#oneflow.Tensor.to_local) 方法得到。例如：
+如果想得到 Global Tensor 的本地分量，可以通过 [to_local](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.Tensor.to_local.html) 方法得到。例如：
 
 ```python
 import oneflow as flow
@@ -178,7 +178,7 @@ Global Tensor 相比普通的 Local Tensor，从类型上讲，最大的区别�
 - 参数 `type` 指定了物理设备的类型，`cuda` 表示 GPU 设备内存, `cpu` 表示 CPU 设备内存；
 - 参数 `ranks` 指定了进程 ID 集合，因为隐含了一个 Rank 对应一个物理设备，所以 `ranks` 就是设备 ID 集合; 实际上 `ranks` 是一个由 rank id 组成 nd-array，支持高维设备排布。 
 
-详情参考 [oneflow.placement](https://oneflow.readthedocs.io/en/master/tensor_attributes.html?highlight=placement#oneflow.placement)。
+详情参考 [oneflow.placement](https://oneflow.readthedocs.io/en/v0.8.1/tensor_attributes.html#oneflow.placement)。
 
 
 全局数据分布类型中的 SBP 指定了全局数据和局部数据的关系:
@@ -189,15 +189,15 @@ Global Tensor 相比普通的 Local Tensor，从类型上讲，最大的区别�
 
 - P，即 partial_sum，局部和全局是部分关系，表示做了 element-wise 累加的数据分布关系；
 
-详情参考 [oneflow.sbp.sbp](https://oneflow.readthedocs.io/en/master/tensor_attributes.html?highlight=placement#oneflow.sbp.sbp)。
+详情参考 [oneflow.sbp.sbp](https://oneflow.readthedocs.io/en/v0.8.1/tensor_attributes.html#oneflow.sbp.sbp)。
 
 数据重分布（Re-distribution)是并行计算中经常要处理的，即变换数据分布，比如把分片数据聚合到一起。在 MPI 编程范式（SPMD）下, 数据重分布需要写显式的通信操作，如 AllReduce、AllGather、ReduceScatter。在 OneFlow 的 Global View 编程范式（SPSD) 下，数据重分布可以通过 Global Tensor 的全局数据分布类型转换完成。
 
 全局数据分布类型的转换类似常规编程语言中的（显式）类型转换。类型转换时，只需指定要变换到的类型，里面隐含的操作会被系统自动完成。比如 double 类型到 int 类型的转换，去掉小数点部分的操作就是系统自动完成的。
 
-同样，只需指定 Global Tensor 要转换的新全局数据分布类型，里面隐含的通信操作会被 OneFlow 自动完成。全局数据分布类型转换的接口是 [Tensor.to_global](https://oneflow.readthedocs.io/en/master/tensor.html#oneflow.Tensor.to_global)，`to_global` 有 `placement` 和 `sbp` 两个参数，这两个参数即期望转换成的新全局数据分布类型。 
+同样，只需指定 Global Tensor 要转换的新全局数据分布类型，里面隐含的通信操作会被 OneFlow 自动完成。全局数据分布类型转换的接口是 [Tensor.to_global](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.Tensor.to_global.html)，`to_global` 有 `placement` 和 `sbp` 两个参数，这两个参数即期望转换成的新全局数据分布类型。
 
-全局数据分布类型转换中隐含的主要操作是通信的推理和执行，背后的实现机制是 OneFlow 的 [Boxing](https://docs.oneflow.org/master/parallelism/03_consistent_tensor#boxing-sbp)，一种自动做数据 Re-distribution 的机制。
+全局数据分布类型转换中隐含的主要操作是通信的推理和执行，背后的实现机制是 OneFlow 的 [Boxing](../parallelism/03_consistent_tensor#boxing-sbp)，一种自动做数据 Re-distribution 的机制。
 
 下面看一个例子，该例子可以把一个按 split 分布的 Global Tensor 转换为一个按 broadcast 分布的 Global Tensor：
 

--- a/cn/docs/cookies/one_embedding.md
+++ b/cn/docs/cookies/one_embedding.md
@@ -54,7 +54,7 @@ tables = [
 
 配置词表时需要指定初始化的方式，以上词表均采用 `uniform` 方式初始化。配置词表的结果保存在 `tables` 变量中。
 
-点击 [make_table_options](https://oneflow.readthedocs.io/en/master/one_embedding.html#oneflow.one_embedding.make_table_options) 及 [make_uniform_initializer](https://oneflow.readthedocs.io/en/master/one_embedding.html#oneflow.one_embedding.make_uniform_initializer) 可以查看有关它们的更详细说明。
+点击 [make_table_options](https://oneflow.readthedocs.io/en/v0.8.1/one_embedding.html#oneflow.one_embedding.make_table_options) 及 [make_uniform_initializer](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.one_embedding.make_uniform_initializer.html#oneflow.one_embedding.make_uniform_initializer) 可以查看有关它们的更详细说明。
 
 ### 配置词表的存储属性
 
@@ -70,9 +70,9 @@ store_options = flow.one_embedding.make_cached_ssd_store_options(
 )
 ```
 
-这里通过调用 `make_cached_ssd_store_options`，选择将词表存储在 SSD 中，并且使用 GPU 作为高速缓存。具体参数的意义可以参阅 [make_cached_ssd_store_options API 文档](https://oneflow.readthedocs.io/en/master/one_embedding.html#oneflow.one_embedding.make_cached_ssd_store_options)。
+这里通过调用 `make_cached_ssd_store_options`，选择将词表存储在 SSD 中，并且使用 GPU 作为高速缓存。具体参数的意义可以参阅 [make_cached_ssd_store_options API 文档](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.one_embedding.make_cached_ssd_store_options.html)。
 
-此外，还可以选择使用纯 GPU 存储；或者使用 CPU 内存存储词表、但用 GPU 做高速缓存。具体可以分别参阅 [make_device_mem_store_options](https://oneflow.readthedocs.io/en/master/one_embedding.html#oneflow.one_embedding.make_device_mem_store_options) 及 [make_cached_host_mem_store_options](https://oneflow.readthedocs.io/en/master/one_embedding.html#oneflow.one_embedding.make_cached_host_mem_store_options)。
+此外，还可以选择使用纯 GPU 存储；或者使用 CPU 内存存储词表、但用 GPU 做高速缓存。具体可以分别参阅 [make_device_mem_store_options](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.one_embedding.make_device_mem_store_options.html) 及 [make_cached_host_mem_store_options](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.one_embedding.make_cached_host_mem_store_options.html)。
 
 ### 实例化 Embedding
 
@@ -94,7 +94,7 @@ embedding.to("cuda")
 
 其中，`tables` 是之前通过 `make_table_options` 配置的词表属性，`store_options` 是之前配置的存储属性，`embedding_dim` 是特征维度，`dtype` 是特征向量的数据类型，`key_type` 是特征 ID 的数据类型。
 
-如果同时创建了两个 OneEmbedding，在实例化时需要设置不同的 name 和 persistent path 参数。 更详细的信息，可以参阅 [one_embedding.MultiTableEmbedding](https://oneflow.readthedocs.io/en/master/one_embedding.html#oneflow.one_embedding.MultiTableEmbedding)
+如果同时创建了两个 OneEmbedding，在实例化时需要设置不同的 name 和 persistent path 参数。 更详细的信息，可以参阅 [one_embedding.MultiTableEmbedding](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.one_embedding.MultiTableEmbedding.forward.html)
 
 ### 使用 Graph 训练
 
@@ -182,7 +182,7 @@ table_ids = np.array([0, 1, 2, 0, 1, 2])
 embedding_lookup(ids, table_ids)
 ```
 
-更详细的说明，可以参阅 [MultiTableEmbedding.forward](https://oneflow.readthedocs.io/en/master/one_embedding.html#oneflow.one_embedding.MultiTableEmbedding.forward)
+更详细的说明，可以参阅 [MultiTableEmbedding.forward](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.one_embedding.MultiTableEmbedding.forward.html)
 
 ### 如何选择合适的存储配置
 

--- a/cn/docs/cookies/one_embedding.md
+++ b/cn/docs/cookies/one_embedding.md
@@ -203,7 +203,7 @@ OneEmbedding 提供了三种存储选项配置，分别是纯 GPU 存储， 存�
 
 ### 分布式训练
 
-OneEmbedding 同 OneFlow 的其它模块类似，都原生支持分布式扩展。用户可以参考 [#dlrm](扩展阅读：DLRM) 中的 README， 启动 DLRM 分布式训练。还可以参考 [Global Tensor](../parallelism/03_consistent_tensor.md) 了解必要的前置知识。
+OneEmbedding 同 OneFlow 的其它模块类似，都原生支持分布式扩展。用户可以参考 [#dlrm](https://github.com/Oneflow-Inc/models/tree/main/RecommenderSystems/dlrm) 中的 README， 启动 DLRM 分布式训练。还可以参考 [Global Tensor](../parallelism/03_consistent_tensor.md) 了解必要的前置知识。
 
 使用 OneEmbedding 模块进行分布式扩展，要注意：
 

--- a/cn/docs/parallelism/03_consistent_tensor.md
+++ b/cn/docs/parallelism/03_consistent_tensor.md
@@ -67,7 +67,7 @@
 
 ### 由 global tensor 得到 local tensor
 
-通过 [to_local](https://oneflow.readthedocs.io/en/master/tensor.html#oneflow.Tensor.to_local) 方法可以查看物理设备上的 local tensor：
+通过 [to_local](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.Tensor.to_local.html) 方法可以查看物理设备上的 local tensor：
 
 === "Terminal 0"
     ```python
@@ -87,7 +87,7 @@
 
 ### 由 local tensor 转换得到 global tensor
 
-可以先创建 local tensor，再利用 [Tensor.to_global](https://oneflow.readthedocs.io/en/master/tensor.html#oneflow.Tensor.to_global) 方法，将 local tensor 转为 global tensor。
+可以先创建 local tensor，再利用 [Tensor.to_global](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.Tensor.to_global.html) 方法，将 local tensor 转为 global tensor。
 
 下面的例子中，在2台设备上分别创建了 `shape=(2,5)` 的2个 local tensor。
 注意经过 `to_global` 方法后，得到的 global tensor 的 `shape` 为 `(4,5)`。

--- a/cn/docs/parallelism/04_2d-sbp.md
+++ b/cn/docs/parallelism/04_2d-sbp.md
@@ -6,7 +6,7 @@
 
 ## 2D 设备阵列
 
-我们已经熟悉 1D SBP 的 placement 配置，在 1D SBP 的场景下，通过 [oneflow.placement](https://start.oneflow.org/oneflow-api-cn/placement.html#oneflow.placement) 接口配置集群，比如使用集群中的第 0~3 号 GPU 显卡：
+我们已经熟悉 1D SBP 的 placement 配置，在 1D SBP 的场景下，通过 [oneflow.placement](https://oneflow.readthedocs.io/en/v0.8.1/tensor_attributes.html?highlight=oneflow.placement#oneflow-placement) 接口配置集群，比如使用集群中的第 0~3 号 GPU 显卡：
 
 ```python
 >>> placement1 = flow.placement("cuda", ranks=[0, 1, 2, 3])

--- a/cn/docs/parallelism/04_2d-sbp.md
+++ b/cn/docs/parallelism/04_2d-sbp.md
@@ -114,9 +114,9 @@ x = flow.randn(1, 2, 8)
 global_x = x.to_global(placement=PLACEMENT, sbp=BS0)
 pred = model(global_x)
 ```
-在这里，我们创建了一个形状为 `(1, 2, 8)` 的 local tensor，然后通过 [Tensor.to_global](https://oneflow.readthedocs.io/en/master/tensor.html#oneflow.Tensor.to_global) 方法获取对应的 global tensor，最后将其输入到模型中进行推理。
+在这里，我们创建了一个形状为 `(1, 2, 8)` 的 local tensor，然后通过 [Tensor.to_global](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.Tensor.to_global.html) 方法获取对应的 global tensor，最后将其输入到模型中进行推理。
 
-通过 [Tensor.to_local](https://oneflow.readthedocs.io/en/master/tensor.html#oneflow.Tensor.to_local) 方法获取当前物理设备上的 local tensor 后，我们可以通过输出其形状和值来验证数据是否被正确处理：
+通过 [Tensor.to_local](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.Tensor.to_local.html) 方法获取当前物理设备上的 local tensor 后，我们可以通过输出其形状和值来验证数据是否被正确处理：
 ```python
 local_x = global_x.to_local()
 print(f'{local_x.device}, {local_x.shape}, \n{local_x}')

--- a/cn/docs/parallelism/05_ddp.md
+++ b/cn/docs/parallelism/05_ddp.md
@@ -181,6 +181,6 @@ python3 -m oneflow.distributed.launch --nproc_per_node 2 ./ddp_train.py
 
 ### DistributedSampler
 
-本文为了简化问题，突出 `DistributedDataParallel`，因此使用的数据是手工分发的。在实际应用中，可以直接使用 [DistributedSampler](https://oneflow.readthedocs.io/en/master/utils.html#oneflow.utils.data.distributed.DistributedSampler) 配合数据并行使用。
+本文为了简化问题，突出 `DistributedDataParallel`，因此使用的数据是手工分发的。在实际应用中，可以直接使用 [DistributedSampler](https://oneflow.readthedocs.io/en/v0.8.1/utils.data.html?highlight=DistributedSampler#oneflow.utils.data.distributed.DistributedSampler) 配合数据并行使用。
 
 `DistributedSampler` 会在每个进程中实例化 Dataloader，每个 Dataloader 实例会加载完整数据的一部分，自动完成数据的分发。

--- a/cn/docs/parallelism/05_ddp.md
+++ b/cn/docs/parallelism/05_ddp.md
@@ -5,7 +5,7 @@
 
 一种是使用 OneFlow 的原生的 SBP 概念，通过设置 global 张量，进行数据并行训练，这也是用 OneFlow 做数据并行训练的 **推荐方式** 。
 
-此外，为了方便从 PyTorch 迁移到 OneFlow 的用户，OneFlow 提供了与 `torch.nn.parallel.DistributedDataParallel` 对齐一致的接口 [oneflow.nn.parallel.DistributedDataParallel](https://oneflow.readthedocs.io/en/master/distributed.html#distributeddataparallel)，它也能让用户方便地从单机训练脚本，扩展为数据并行训练。
+此外，为了方便从 PyTorch 迁移到 OneFlow 的用户，OneFlow 提供了与 `torch.nn.parallel.DistributedDataParallel` 对齐一致的接口 [oneflow.nn.parallel.DistributedDataParallel](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.parallel.DistributedDataParallel.html)，它也能让用户方便地从单机训练脚本，扩展为数据并行训练。
 
 ## 通过设置 SBP 做数据并行训练
 
@@ -171,7 +171,7 @@ w:tensor([[2.0000],
 可以发现，它与单机单卡脚本的不同只有2个：
 
 - 使用 `DistributedDataParallel` 处理一下 module 对象（`m = ddp(m)`)
-- 使用 [get_rank](https://oneflow.readthedocs.io/en/master/oneflow.html#oneflow.env.get_rank) 获取当前设备编号，并针对设备分发数据
+- 使用 [get_rank](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.env.get_rank.html) 获取当前设备编号，并针对设备分发数据
 
 然后使用 `launcher` 启动脚本，把剩下的一切都交给 OneFlow，让分布式训练，像单机单卡训练一样简单：
 

--- a/cn/docs/parallelism/06_pipeline.md
+++ b/cn/docs/parallelism/06_pipeline.md
@@ -65,8 +65,8 @@
         def __init__(self):
             super().__init__()
             self.module_pipeline = module_pipeline
-            self.module_pipeline.m_stage0.config.stage_id = 0
-            self.module_pipeline.m_stage1.config.stage_id = 1
+            self.module_pipeline.m_stage0.config.set_stage(stage_id=0, placement=P0)
+            self.module_pipeline.m_stage1.config.set_stage(stage_id=1, placement=P1)
             self.loss_fn = flow.nn.CrossEntropyLoss()
             self.config.set_gradient_accumulation_steps(2)
             self.add_optimizer(sgd)
@@ -142,14 +142,14 @@ P1 = flow.placement("cuda", ranks=[1])
 
 在实际训练中，各个计算设备也可以加载属于各自的本地数据，然后通过 `to_global` 实现 Local Tensor 到 Global Tensor 的转化。
 
-### Stage ID 及 梯度累积设置
+### Stage ID 及梯度累积设置
 
-通过设置 Module 的 `config.stage_id` 属性，设置 Stage ID，Stage ID 从 0 开始编号，依次加1。
-调用 `self.config.set_gradient_accumulation_steps` 方法，设置梯度累积的步长。
+通过 Module Config 上的 [config.set_stage](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.graph.block_config.BlockConfig.set_stage.html) 方法，设置流水线 Stage ID 和 Stage 对应的 Placement，Stage ID 从 0 开始编号，依次加 1。
+调用 [config.set_gradient_accumulation_steps](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.graph.graph_config.GraphConfig.set_gradient_accumulation_steps.html#oneflow.nn.graph.graph_config.GraphConfig.set_gradient_accumulation_steps) 方法，设置梯度累积的步长。
 OneFlow 通过这两项配置，获取实现流水并行中的 micro batch 技术所需的信息。
 
 ```python
-    self.module_pipeline.m_stage0.config.stage_id = 0
-    self.module_pipeline.m_stage1.config.stage_id = 1
+    self.module_pipeline.m_stage0.config.set_stage(stage_id=0, placement=P0)
+    self.module_pipeline.m_stage1.config.set_stage(stage_id=1, placement=P1)
     self.config.set_gradient_accumulation_steps(2)
 ```

--- a/cn/docs/parallelism/06_pipeline.md
+++ b/cn/docs/parallelism/06_pipeline.md
@@ -108,7 +108,7 @@ P1 = flow.placement("cuda", ranks=[1])
 
 `P0`、`P1` 分别代表集群的第 0 个 GPU 和第 1 个 GPU。
 
-通过调用 [nn.Module.to_global](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.Module.html?highlight=nn.Module) 或 [Tensor.to_global](https://oneflow.readthedocs.io/en/master/tensor.html?highlight=to_global#oneflow.Tensor.to_global) 就可以将模型或张量分配到指定的计算设备上运行，将一个网络拆分为多个流水阶段（stage）。
+通过调用 [nn.Module.to_global](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.Module.html) 或 [Tensor.to_global](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.Tensor.to_global.html) 就可以将模型或张量分配到指定的计算设备上运行，将一个网络拆分为多个流水阶段（stage）。
 
 在此我们定义了一个 `PipelineModule` 专门设置各阶段的流水。
 

--- a/cn/docs/parallelism/06_pipeline.md
+++ b/cn/docs/parallelism/06_pipeline.md
@@ -108,7 +108,7 @@ P1 = flow.placement("cuda", ranks=[1])
 
 `P0`、`P1` 分别代表集群的第 0 个 GPU 和第 1 个 GPU。
 
-通过调用 [nn.Module.to_global](https://oneflow.readthedocs.io/en/master/module.html?highlight=to_global#oneflow.nn.Module.to_global) 或 [Tensor.to_global](https://oneflow.readthedocs.io/en/master/tensor.html?highlight=to_global#oneflow.Tensor.to_global) 就可以将模型或张量分配到指定的计算设备上运行，将一个网络拆分为多个流水阶段（stage）。
+通过调用 [nn.Module.to_global](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.Module.html?highlight=nn.Module) 或 [Tensor.to_global](https://oneflow.readthedocs.io/en/master/tensor.html?highlight=to_global#oneflow.Tensor.to_global) 就可以将模型或张量分配到指定的计算设备上运行，将一个网络拆分为多个流水阶段（stage）。
 
 在此我们定义了一个 `PipelineModule` 专门设置各阶段的流水。
 

--- a/en/docs/basics/01_quickstart.md
+++ b/en/docs/basics/01_quickstart.md
@@ -128,7 +128,7 @@ NeuralNetwork(
 
 ## Training Models
 
-To train a model, we need a loss function (`loss_fn`) and an optimizer (`optimizer`). The loss function is used to evaluate the difference between the prediction of the neural network and the real label. The optimizer adjusts the parameters of the neural network to make the prediction closer to the real label (expected answer). Here, we use [oneflow.optim.SGD](https://oneflow.readthedocs.io/en/master/optim.html?highlight=optim.SGD#oneflow.optim.SGD) to be our optimizer. This process is called back propagation.
+To train a model, we need a loss function (`loss_fn`) and an optimizer (`optimizer`). The loss function is used to evaluate the difference between the prediction of the neural network and the real label. The optimizer adjusts the parameters of the neural network to make the prediction closer to the real label (expected answer). Here, we use [oneflow.optim.SGD](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.optim.SGD.html) to be our optimizer. This process is called back propagation.
 
 ```python
 loss_fn = nn.CrossEntropyLoss().to(DEVICE)
@@ -223,7 +223,7 @@ loss: 1.835239  [12800/60000]
 
 ## Saving and Loading Models
 
-Use [oneflow.save](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.save#oneflow.save) to save the model. The saved model can be then loaded by [oneflow.load](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.load#oneflow.load) to make predictions.
+Use [oneflow.save](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.save.html) to save the model. The saved model can be then loaded by [oneflow.load](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.load.html) to make predictions.
 
 ```python
 flow.save(model.state_dict(), "./model")

--- a/en/docs/basics/01_quickstart.md
+++ b/en/docs/basics/01_quickstart.md
@@ -58,7 +58,7 @@ Extracting data/FashionMNIST/raw/train-images-idx3-ubyte.gz to data/FashionMNIST
 
 The data will be downloaded and extracted to`./data` directory.
 
-The [oneflow.utils.data.DataLoader](https://oneflow.readthedocs.io/en/master/utils.html#oneflow.utils.data.DataLoader) wraps an iterable around the `dataset`.
+The [oneflow.utils.data.DataLoader](https://oneflow.readthedocs.io/en/v0.8.1/utils.data.html?highlight=oneflow.utils.data.DataLoader#oneflow.utils.data.DataLoader) wraps an iterable around the `dataset`.
 
 ```python
 train_dataloader = flow.utils.data.DataLoader(

--- a/en/docs/basics/02_tensor.md
+++ b/en/docs/basics/02_tensor.md
@@ -164,7 +164,7 @@ oneflow.int32 cuda:0
 
 ## Operations on Tensors
 
-A large number of operators are provided in OneFlow, most of which are in the namespaces of [oneflow](https://oneflow.readthedocs.io/en/master/oneflow.html), [oneflow.nn](https://oneflow.readthedocs.io/en/master/nn.html), and [oneflow.nn.functional](https://oneflow.readthedocs.io/en/master/functional.html).
+A large number of operators are provided in OneFlow, most of which are in the namespaces of [oneflow](https://oneflow.readthedocs.io/en/master/oneflow.html), [oneflow.nn](https://oneflow.readthedocs.io/en/master/nn.html), and [oneflow.nn.functional](https://oneflow.readthedocs.io/en/v0.8.1/nn.functional.html).
 
 Tensors in OneFlow are as easy to use as the NumPy arrays. For example, slicing in NumPy style is supported:
 

--- a/en/docs/basics/02_tensor.md
+++ b/en/docs/basics/02_tensor.md
@@ -61,7 +61,7 @@ tensor([[0.6213, 0.6142, 0.1592],
 
 ### By an operator
 
-There are also many operators available in OneFlow that can be used to create tensors. For example, [ones](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.ones#oneflow.ones), [zeros](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.zeros#oneflow.zeros) and [eye](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.eye#oneflow.eye), which create the all-ones tensor, zero tensor, and identity tensor, respectively.
+There are also many operators available in OneFlow that can be used to create tensors. For example, [ones](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.ones.html), [zeros](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.zeros.html) and [eye](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.eye.html), which create the all-ones tensor, zero tensor, and identity tensor, respectively.
 
 ```python
 x5 = flow.ones(2, 3)
@@ -84,7 +84,7 @@ tensor([[1., 0., 0.],
         [0., 0., 1.]], dtype=oneflow.float32)
 ```
 
-The [randn](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.randn#oneflow.randn) method creates a random tensor:
+The [randn](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.randn.html) method creates a random tensor:
 
 ```python
 x8 = flow.randn(2,3)
@@ -92,7 +92,7 @@ x8 = flow.randn(2,3)
 
 ## Difference Between `Tensor` and `tensor`
 
-There are two interfaces ([oneflow.Tensor](https://oneflow.readthedocs.io/en/master/tensor.html?highlight=oneflow.Tensor#oneflow.Tensor) and [oneflow.tensor](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.Tensor#oneflow.tensor)) in OneFlow, both of which can be used to create tensors. What’s the difference between them?
+There are two interfaces ([oneflow.Tensor](https://oneflow.readthedocs.io/en/v0.8.1/tensor.html) and [oneflow.tensor](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.tensor.html)) in OneFlow, both of which can be used to create tensors. What’s the difference between them?
 
 Briefly speaking, the data type of `oneflow.Tensor` is limited to `float32` by default, while the data type of `oneflow.tensor` can be changed when the data is created. The following code illustrates the difference:
 
@@ -146,7 +146,7 @@ cpu:0
 
 The output shows the shape, the data type, and the device (on CPU No. 0, CPUs were numbered because OneFlow naturally supports distribution, see [Global Tensor](../parallelism/03_consistent_tensor.md)).
 
-The shape of the tensor can be changed by the [reshape](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.reshape#oneflow.reshape) method, and the data type and device of the tensor can be changed by the [to](https://oneflow.readthedocs.io/en/master/tensor.html?highlight=Tensor.to#oneflow.Tensor.to) method:
+The shape of the tensor can be changed by the [reshape](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.reshape.html) method, and the data type and device of the tensor can be changed by the [Tensor.to](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.Tensor.to.html) method:
 
 ```python
 x10 = x9.reshape(2, 2)
@@ -164,7 +164,7 @@ oneflow.int32 cuda:0
 
 ## Operations on Tensors
 
-A large number of operators are provided in OneFlow, most of which are in the namespaces of [oneflow](https://oneflow.readthedocs.io/en/master/oneflow.html), [oneflow.nn](https://oneflow.readthedocs.io/en/master/nn.html), and [oneflow.nn.functional](https://oneflow.readthedocs.io/en/v0.8.1/nn.functional.html).
+A large number of operators are provided in OneFlow, most of which are in the namespaces of [oneflow](https://oneflow.readthedocs.io/en/v0.8.1/oneflow.html), [oneflow.Tensor](https://oneflow.readthedocs.io/en/v0.8.1/tensor.html), [oneflow.nn](https://oneflow.readthedocs.io/en/master/nn.html), and [oneflow.nn.functional](https://oneflow.readthedocs.io/en/v0.8.1/nn.functional.html).
 
 Tensors in OneFlow are as easy to use as the NumPy arrays. For example, slicing in NumPy style is supported:
 
@@ -189,4 +189,4 @@ tensor([[1., 0., 1., 1.],
         [1., 0., 1., 1.]], dtype=oneflow.float32)
 ```
 
-In addition, there are many other operations in OneFlow, such as [add](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.add#oneflow.add), [sub](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.sub#oneflow.sub), [mul](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.mul#oneflow.mul), [div](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.div#oneflow.div) for arithmetic operations; [scatter](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.scatter#oneflow.scatter), [gather](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.gather#oneflow.gather), [gather_nd](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.gather_nd#oneflow.gather_nd) for positional operations; and activation functions ([relu](https://oneflow.readthedocs.io/en/master/functional.html?highlight=oneflow.relu#oneflow.nn.functional.relu)), convolution functions ([conv2d](https://oneflow.readthedocs.io/en/master/functional.html?highlight=oneflow.conv2d#oneflow.nn.functional.conv2d)), etc. Click on their links to see detailed API description and find out more about other operators.
+In addition, there are many other operations in OneFlow, such as [add](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.add.html), [sub](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.sub.html), [mul](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.mul.html), [div](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.div.html) for arithmetic operations; [scatter](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.scatter.html), [gather](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.gather.html) for positional operations; and activation functions ([relu](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.functional.relu.html)), convolution functions ([conv2d](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.functional.conv2d.html)), etc. Click on their links to see detailed API description and find out more about other operators.

--- a/en/docs/basics/03_dataset_dataloader.md
+++ b/en/docs/basics/03_dataset_dataloader.md
@@ -104,7 +104,7 @@ plt.show()
 
 ## Creating a Custom Dataset for Your Files
 
-A custom dataset can be defined by inheriting [oneflow.utils.data.Dataset](https://oneflow.readthedocs.io/en/master/utils.html?highlight=oneflow.utils.data.Dataset#oneflow.utils.data.Dataset). Custom `Dataset` can be used with `Dataloader` introduced in the next section to simplify data processing.
+A custom dataset can be defined by inheriting [oneflow.utils.data.Dataset](https://oneflow.readthedocs.io/en/v0.8.1/utils.data.html?highlight=utils.data.Dataset#oneflow.utils.data.Dataset). Custom `Dataset` can be used with `Dataloader` introduced in the next section to simplify data processing.
 
 Here is an example of how to create a custom `Dataset`, the key steps are:
 

--- a/en/docs/basics/03_dataset_dataloader.md
+++ b/en/docs/basics/03_dataset_dataloader.md
@@ -104,7 +104,7 @@ plt.show()
 
 ## Creating a Custom Dataset for Your Files
 
-A custom dataset can be defined by inheriting [oneflow.utils.data.Dataset](https://oneflow.readthedocs.io/en/v0.8.1/utils.data.html?highlight=utils.data.Dataset#oneflow.utils.data.Dataset). Custom `Dataset` can be used with `Dataloader` introduced in the next section to simplify data processing.
+A custom dataset can be defined by inheriting [oneflow.utils.data.Dataset](https://oneflow.readthedocs.io/en/v0.8.1/utils.data.html#oneflow.utils.data.Dataset). Custom `Dataset` can be used with `Dataloader` introduced in the next section to simplify data processing.
 
 Here is an example of how to create a custom `Dataset`, the key steps are:
 

--- a/en/docs/basics/04_build_network.md
+++ b/en/docs/basics/04_build_network.md
@@ -1,6 +1,6 @@
 # BUILD NEURAL NETWORK
 
-The layers of a neural network can be built by API in namespace [oneflow.nn](https://oneflow.readthedocs.io/en/master/nn.html), It provides common Module (such as [oneflow.nn.Conv2d](https://oneflow.readthedocs.io/en/master/nn.html?highlight=oneflow.nn.Conv2D#oneflow.nn.Conv2d), [oneflow.nn.ReLU](https://oneflow.readthedocs.io/en/master/nn.html?highlight=oneflow.nn.ReLU#oneflow.nn.ReLU)). All Module classes inherit from [oneflow.nn.Module](https://oneflow.readthedocs.io/en/master/module.html#oneflow.nn.Module), and many simple Module can form more complex Module. In this way, users can easily build and manage complex neural networks.
+The layers of a neural network can be built by API in namespace [oneflow.nn](https://oneflow.readthedocs.io/en/master/nn.html), It provides common Module (such as [oneflow.nn.Conv2d](https://oneflow.readthedocs.io/en/master/nn.html?highlight=oneflow.nn.Conv2D#oneflow.nn.Conv2d), [oneflow.nn.ReLU](https://oneflow.readthedocs.io/en/master/nn.html?highlight=oneflow.nn.ReLU#oneflow.nn.ReLU)). All Module classes inherit from [oneflow.nn.Module](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.Module.html?highlight=oneflow.nn.Module#oneflow.nn.Module), and many simple Module can form more complex Module. In this way, users can easily build and manage complex neural networks.
 
 ```python
 import oneflow as flow
@@ -75,7 +75,7 @@ The above process of data input, network calculation and the output of reasoning
 
 ## `flow.nn.functional`
 
-In addition to `oneflow.nn`, [oneflow.nn.functional](https://oneflow.readthedocs.io/en/master/functional.html) namespace also provides many API. It overlaps with `oneflow.nn` to some extent. For example, [nn.functional.relu](https://oneflow.readthedocs.io/en/master/functional.html?highlight=relu#oneflow.nn.functional.relu) and [nn.ReLU](https://oneflow.readthedocs.io/en/master/nn.html?highlight=relu#oneflow.nn.ReLU) both can be used for activation in neural network.
+In addition to `oneflow.nn`, [oneflow.nn.functional](https://oneflow.readthedocs.io/en/v0.8.1/nn.functional.html) namespace also provides many API. It overlaps with `oneflow.nn` to some extent. For example, [nn.functional.relu](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.functional.relu.html) and [nn.ReLU](https://oneflow.readthedocs.io/en/master/nn.html?highlight=relu#oneflow.nn.ReLU) both can be used for activation in neural network.
 
 The main differences between them are:
 

--- a/en/docs/basics/04_build_network.md
+++ b/en/docs/basics/04_build_network.md
@@ -1,6 +1,6 @@
 # BUILD NEURAL NETWORK
 
-The layers of a neural network can be built by API in namespace [oneflow.nn](https://oneflow.readthedocs.io/en/master/nn.html), It provides common Module (such as [oneflow.nn.Conv2d](https://oneflow.readthedocs.io/en/master/nn.html?highlight=oneflow.nn.Conv2D#oneflow.nn.Conv2d), [oneflow.nn.ReLU](https://oneflow.readthedocs.io/en/master/nn.html?highlight=oneflow.nn.ReLU#oneflow.nn.ReLU)). All Module classes inherit from [oneflow.nn.Module](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.Module.html?highlight=oneflow.nn.Module#oneflow.nn.Module), and many simple Module can form more complex Module. In this way, users can easily build and manage complex neural networks.
+The layers of a neural network can be built by API in namespace [oneflow.nn](https://oneflow.readthedocs.io/en/v0.8.1/nn.html), It provides common Module (such as [oneflow.nn.Conv2d](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.Conv2d.html), [oneflow.nn.ReLU](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.ReLU.html)). All Module classes inherit from [oneflow.nn.Module](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.Module.html), and many simple Module can form more complex Module. In this way, users can easily build and manage complex neural networks.
 
 ```python
 import oneflow as flow
@@ -75,7 +75,7 @@ The above process of data input, network calculation and the output of reasoning
 
 ## `flow.nn.functional`
 
-In addition to `oneflow.nn`, [oneflow.nn.functional](https://oneflow.readthedocs.io/en/v0.8.1/nn.functional.html) namespace also provides many API. It overlaps with `oneflow.nn` to some extent. For example, [nn.functional.relu](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.functional.relu.html) and [nn.ReLU](https://oneflow.readthedocs.io/en/master/nn.html?highlight=relu#oneflow.nn.ReLU) both can be used for activation in neural network.
+In addition to `oneflow.nn`, [oneflow.nn.functional](https://oneflow.readthedocs.io/en/v0.8.1/nn.functional.html) namespace also provides many API. It overlaps with `oneflow.nn` to some extent. For example, [nn.functional.relu](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.functional.relu.html) and [nn.ReLU](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.ReLU.html) both can be used for activation in neural network.
 
 The main differences between them are:
 
@@ -127,7 +127,7 @@ print(f"Predicted class: {y_pred}")
 
 ## Module container
 
-Comparing the similarities and differences between the `NeuralNetwork` and `FunctionalNeuralNetwork`,we can find that [nn.Sequential](https://oneflow.readthedocs.io/en/master/nn.html?highlight=nn.Sequential#oneflow.nn.Sequential) plays an important role in simplifying the code.
+Comparing the similarities and differences between the `NeuralNetwork` and `FunctionalNeuralNetwork`,we can find that [nn.Sequential](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.Sequential.html) plays an important role in simplifying the code.
 
 `nn.Sequential` is a special container. Any class inherited from `nn.Module` can be placed in it.
 

--- a/en/docs/basics/05_autograd.md
+++ b/en/docs/basics/05_autograd.md
@@ -140,7 +140,7 @@ tensor(20., dtype=oneflow.float32)
 ### Disabled Gradient Calculation
 
 By default, OneFlow will trace and calculate gradients of Tensors with `requires_grad = Ture`.
-However, in some cases, we don't need OneFlow to keep tracing gradients such as just wanting the forward pass for inference. Then we can use [oneflow.no_grad()](https://oneflow.readthedocs.io/en/master/oneflow.html#oneflow.no_grad) or [oneflow.Tensor.detach()](https://oneflow.readthedocs.io/en/master/tensor.html#oneflow.Tensor.detach) to set.
+However, in some cases, we don't need OneFlow to keep tracing gradients such as just wanting the forward pass for inference. Then we can use [oneflow.no_grad](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.no_grad.html) or [oneflow.Tensor.detach](https://oneflow.readthedocs.io/en/master/generated/oneflow.Tensor.detach.html#oneflow.Tensor.detach) to set.
 
 ```python
 z = flow.matmul(x, w)+b

--- a/en/docs/basics/06_optimization.md
+++ b/en/docs/basics/06_optimization.md
@@ -2,7 +2,7 @@
 
 So far, we have learned how to use OneFlow to [Dataset and DataLoader](./03_dataset_dataloader.md), [Build Models](./04_build_network.md),[Autograd](./05_autograd.md), and combine them so that we can train models by using backpropagation algorithms.
 
-In [oneflow.optim](https://oneflow.readthedocs.io/en/master/optim.html), there are various `optimizer`s that simplify the code of back propagation.
+In [oneflow.optim](https://oneflow.readthedocs.io/en/v0.8.1/optim.html), there are various `optimizer`s that simplify the code of back propagation.
 
 This article will first introduce the basic concepts of back propagation and then show you how to use the `oneflow.optim` class.
 
@@ -123,7 +123,7 @@ model = MyLrModule(0.01, 500)
 
 ### Loss function
 
-Then, select the loss function. OneFlow comes with a variety of loss functions. We choose [MSELoss](https://oneflow.readthedocs.io/en/master/nn.html?highlight=mseloss#oneflow.nn.MSELoss) here：
+Then, select the loss function. OneFlow comes with a variety of loss functions. We choose [MSELoss](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.MSELoss.html) here：
 
 ```python
 loss = flow.nn.MSELoss(reduction="sum")
@@ -131,7 +131,7 @@ loss = flow.nn.MSELoss(reduction="sum")
 
 ### Construct Optimizer
 
-The logic of back propagation is wrapped in optimizer. We choose [SGD](https://oneflow.readthedocs.io/en/master/optim.html?highlight=sgd#oneflow.optim.SGD) here, You can choose other optimization algorithms as needed, such as [Adam](https://oneflow.readthedocs.io/en/master/optim.html?highlight=adam#oneflow.optim.Adam) and[AdamW](https://oneflow.readthedocs.io/en/master/optim.html?highlight=adamw#oneflow.optim.AdamW) .
+The logic of back propagation is wrapped in optimizer. We choose [SGD](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.optim.SGD.html) here, You can choose other optimization algorithms as needed, such as [Adam](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.optim.Adam.html) and[AdamW](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.optim.AdamW.html) .
 
 ```python
 optimizer = flow.optim.SGD(model.parameters(), model.lr)

--- a/en/docs/basics/07_model_load_save.md
+++ b/en/docs/basics/07_model_load_save.md
@@ -5,7 +5,7 @@ There are two common uses for loading and saving models:
 - Save the model that has been trained to continue training next time.
 - Save the trained model for direct prediction in the future.
 
-We will introduce how to use [save](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.save#oneflow.save) and [load](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.load#oneflow.load) to save and load models as follows.
+We will introduce how to use [save](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.save.html) and [load](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.load.html) to save and load models as follows.
 
 Also, we will show how to load a pre-trained model for inference.
 
@@ -51,7 +51,7 @@ OrderedDict([('weight',
 
 ## Saving Models
 
-We can use [oneflow.save](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.save#oneflow.save) to save models.
+We can use [oneflow.save](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.save.html) to save models.
 
 ```python
 flow.save(m.state_dict(), "./model")
@@ -61,7 +61,7 @@ The first parameter is the Module parameters, and the second is the saved path. 
 
 ## Loading Models
 
-Using [oneflow.load](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.load#oneflow.load) to load parameters from disk  to memory with the specified path, and get the dictionary of the parameters.
+Using [oneflow.load](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.load.html) to load parameters from disk  to memory with the specified path, and get the dictionary of the parameters.
 
 ```python
 params = flow.load("./model")

--- a/en/docs/basics/08_nn_graph.md
+++ b/en/docs/basics/08_nn_graph.md
@@ -4,7 +4,7 @@ At present, there are two ways to run models in deep learning framework, **Dynam
 
 There are pros and cons to both approaches, and OneFlow offers support for both, with the Eager Mode by default. If you are reading the tutorials for this basic topic in order, then all the code you have encountered so far is in Eager Mode.
 
-In general, dynamic graphs are easier to use and static graphs have better performance. OneFlow offers [nn.Graph](https://oneflow.readthedocs.io/en/master/graph.html), so that users can use the eager-like programming style to build static graphs and train the models.
+In general, dynamic graphs are easier to use and static graphs have better performance. OneFlow offers [nn.Graph](https://oneflow.readthedocs.io/en/v0.8.1/graph.html), so that users can use the eager-like programming style to build static graphs and train the models.
 
 ## Eager Mode in OneFlow
 
@@ -80,7 +80,7 @@ loss: 6.644351  [  960/50000]
 
 ### Customize a Graph
 
-OneFlow provide the base class [nn.Graph](https://oneflow.readthedocs.io/en/master/graph.html), which can be inherited to create a customized Graph class.
+OneFlow provide the base class [nn.Graph](https://oneflow.readthedocs.io/en/v0.8.1/graph.html), which can be inherited to create a customized Graph class.
 
 ```python
 import oneflow as flow
@@ -320,7 +320,7 @@ If you use `print` **after** the Graph object is called, in addition to the stru
     ...
 ```
 
-**The second** way is that by calling the [debug](https://oneflow.readthedocs.io/en/master/graph.html#oneflow.nn.Graph.debug) method of Graph objects, Graph’s debug mode is turned on.
+**The second** way is that by calling the [debug](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.Graph.debug.html) method of Graph objects, Graph’s debug mode is turned on.
 
 ```python
 graph_mobile_net_v2.debug(v_level=1) # The defalut of v_level is 0.
@@ -366,7 +366,7 @@ In addition to the methods described above, getting the parameters of the gradie
 
 When training Graph model, it is often necessary to save the parameters of the model that has been trained for a period of time and other states such as optimizer parameters, so as to facilitate the resume of training after interruption.
 
-Graph model objects have `state_dict` and `load_state_dict` interfaces that similar to Module. We can save and load graph models with [save](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.save#oneflow.save) and [load](https://oneflow.readthedocs.io/en/master/oneflow.html?highlight=oneflow.load#oneflow.load). This is similar to Eagar module introduced in [Model Save and Load](../basics/07_model_load_save.md). A little different from Eager mode is that when calling Graph's `state_dict` during training, in addition to the parameters of each layer of the internal Module, other states such as training iteration steps and optimizer parameters will also be obtained, so as to resume training later.
+Graph model objects have `state_dict` and `load_state_dict` interfaces that similar to Module. We can save and load graph models with [save](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.save.html) and [load](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.load.html). This is similar to Eagar module introduced in [Model Save and Load](../basics/07_model_load_save.md). A little different from Eager mode is that when calling Graph's `state_dict` during training, in addition to the parameters of each layer of the internal Module, other states such as training iteration steps and optimizer parameters will also be obtained, so as to resume training later.
 
 For example, we hope to save the latest state after each epoch while training `graph_mobile_net_v2` above, we need to add the following code:
 

--- a/en/docs/cookies/global_tensor.md
+++ b/en/docs/cookies/global_tensor.md
@@ -115,7 +115,7 @@ It’s clear that if we concatenate the Local Tensors in rank 1 and rank 2 on di
 
 ## Converting Local Tensor to Global Tensor
 
-We can firstly create a Local Tensor and then utilize the [Tensor.to_global](https://oneflow.readthedocs.io/en/master/tensor.html#oneflow.Tensor.to_global) method to convert the Local Tensor to a Global Tensor.
+We can firstly create a Local Tensor and then utilize the [Tensor.to_global](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.Tensor.to_global.html) method to convert the Local Tensor to a Global Tensor.
 
 
 Create the following program and launch it in the similar way mentioned above:
@@ -152,7 +152,7 @@ Except for shape, the Global Tensor also contains some data. The Global Tensor h
 
 
 
-You can utilize the [to_local](https://oneflow.readthedocs.io/en/master/tensor.html#oneflow.Tensor.to_local) method to obtain the local component of the Global Tensor, just like the following:
+You can utilize the [to_local](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.Tensor.to_local.html) method to obtain the local component of the Global Tensor, just like the following:
 
 ```python
 import oneflow as flow
@@ -203,7 +203,7 @@ The function of placement in global data distribution type is to specify the dev
 - The parameter `type` specifies the physical device type. `cuda represents the GPU device memory, and `cpu` refers to the CPU device memory.
 - The parameter `ranks` specifies the process ID set. Because each rank corresponds to one physical device, `ranks` can also be seen as the device ID set. Actually, `ranks` is an nd-array composed of rank ID, which supports high-dimensional device arrangement.
 
-For more details, please refer to [oneflow.placement](https://oneflow.readthedocs.io/en/master/tensor_attributes.html?highlight=placement#oneflow.placement).
+For more details, please refer to [oneflow.placement](https://oneflow.readthedocs.io/en/v0.8.1/tensor_attributes.html#oneflow.placement).
 
 
 
@@ -215,7 +215,7 @@ The function of SBP in the global data distribution type is to specify the relat
 
 - P, i.e., partial_sum, notes that the relationship between global data and local data is partial, indicating the value of the global data is the element-wise sum of the local data distributed in each rank.
 
-For more details, please refer to [oneflow.sbp.sbp](https://oneflow.readthedocs.io/en/master/tensor_attributes.html?highlight=placement#oneflow.sbp.sbp).
+For more details, please refer to [oneflow.sbp.sbp](https://oneflow.readthedocs.io/en/v0.8.1/tensor_attributes.html#oneflow.sbp.sbp).
 
 
 Data re-distribution is commonly seen in parallel computing, i.e., changing the distributed way of data, such as gathering all data slices. In the MPI programming paradigm (SPMD), data re-distribution requires writing explicit communication operations like AllReduce, AllGather, and ReduceScatter. But in OneFlow’s Global View programming paradigm (SPSD), data re-distribution can be achieved by utilizing Global Tensor’s global data distribution type conversion.
@@ -223,9 +223,9 @@ Data re-distribution is commonly seen in parallel computing, i.e., changing the 
 
 The conversion of the global data distribution type is similar to (explicit) type conversion in general programming languages. Users only need to specify the targeted type when they convert types, and some implicit operations can be executed automatically. For example, when converting the type from double to int, the system will remove the decimal point automatically.
 
-Similarly, it’s only required to specify the new global data distribution type that the Global Tensor will be converted into, and OneFlow will complete implicit communication operations automatically. And the interface to convert the global data distribution type is [Tensor.to_global](https://oneflow.readthedocs.io/en/master/tensor.html#oneflow.Tensor.to_global). The `to_global` method contains two parameters- `placement` and `sbp`, which decide the newly-converted global data distribution type.
+Similarly, it’s only required to specify the new global data distribution type that the Global Tensor will be converted into, and OneFlow will complete implicit communication operations automatically. And the interface to convert the global data distribution type is [Tensor.to_global](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.Tensor.to_global.html). The `to_global` method contains two parameters- `placement` and `sbp`, which decide the newly-converted global data distribution type.
 
-The main implicit operations in converting the global data distribution type are to infer and execute the communications, and these operations are implemented by OneFlow’s [Boxing](https://docs.oneflow.org/en/master/parallelism/03_consistent_tensor.html#boxingautomatic-conversion-of-sbp), which is a mechanism to re-distribute data automatically.
+The main implicit operations in converting the global data distribution type are to infer and execute the communications, and these operations are implemented by OneFlow’s [Boxing](../parallelism/03_consistent_tensor#boxing-sbp), which is a mechanism to re-distribute data automatically.
 
 
 The following is a case to convert a split-distributed Global Tensor to a broadcast-distributed one:

--- a/en/docs/cookies/one_embedding.md
+++ b/en/docs/cookies/one_embedding.md
@@ -195,7 +195,7 @@ OneEmbedding provides three storage options configurations,they are pure GPU sto
 
 ### Distributed Training
 
-Similar to other modules of OneFlow, OneEmbedding supports distributed expansion natively. Users can refer to the README in [#dlrm](扩展阅读：DLRM) to start DLRM distributed training. You can also refer to [Global Tensor](../parallelism/03_consistent_tensor.md) for necessary prerequisites.
+Similar to other modules of OneFlow, OneEmbedding supports distributed expansion natively. Users can refer to the README in [#dlrm](https://github.com/Oneflow-Inc/models/tree/main/RecommenderSystems/dlrm) to start DLRM distributed training. You can also refer to [Global Tensor](../parallelism/03_consistent_tensor.md) for necessary prerequisites.
 
 When using the OneEmbedding module for distributed expansion, please be careful:
 

--- a/en/docs/cookies/one_embedding.md
+++ b/en/docs/cookies/one_embedding.md
@@ -49,7 +49,7 @@ tables = [
 
 When configuring the Embedding table, you need to specify the initialization method. The above Embedding tables are initialized in the `uniform` method. The result of configuring the Embedding table is stored in the `tables` variable
 
-Click [make_table_options](https://oneflow.readthedocs.io/en/master/one_embedding.html#oneflow.one_embedding.make_table_options) and [make_uniform_initializer](https://oneflow.readthedocs.io/en/master/one_embedding.html#oneflow.one_embedding.make_uniform_initializer) to check more detailed information.
+Click [make_table_options](https://oneflow.readthedocs.io/en/v0.8.1/one_embedding.html#oneflow.one_embedding.make_table_options) and [make_uniform_initializer](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.one_embedding.make_uniform_initializer.html#oneflow.one_embedding.make_uniform_initializer) to check more detailed information.
 
 ### Configure the Storage Attribute of the Embedding Table
 
@@ -65,9 +65,9 @@ store_options = flow.one_embedding.make_cached_ssd_store_options(
 )
 ```
 
-By calling `make_cached_ssd_store_options` here, you can store Embedding table on SSD and use GPU as cache. For the meaning of specific parameters, please refer to [make_cached_ssd_store_options API 文档](https://oneflow.readthedocs.io/en/master/one_embedding.html#oneflow.one_embedding.make_cached_ssd_store_options).
+By calling `make_cached_ssd_store_options` here, you can store Embedding table on SSD and use GPU as cache. For the meaning of specific parameters, please refer to [make_cached_ssd_store_options API 文档](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.one_embedding.make_cached_ssd_store_options.html).
 
-In addition, you can use pure GPU as storage; or use CPU memory to store Embedding table, but use GPU as cache. For more details, please refer to [make_device_mem_store_options](https://oneflow.readthedocs.io/en/master/one_embedding.html#oneflow.one_embedding.make_device_mem_store_options) and [make_cached_host_mem_store_option](https://oneflow.readthedocs.io/en/master/one_embedding.html#oneflow.one_embedding.make_cached_host_mem_store_options).
+In addition, you can use pure GPU as storage; or use CPU memory to store Embedding table, but use GPU as cache. For more details, please refer to [make_device_mem_store_options](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.one_embedding.make_device_mem_store_options.html) and [make_cached_host_mem_store_option](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.one_embedding.make_cached_host_mem_store_options.html).
 
 ### Instantiate Embedding
 
@@ -89,7 +89,7 @@ embedding.to("cuda")
 
 Among them, `tables` is the Embedding table attribute previously configured by `make_table_options`, `store_options` is the previously configured storage attribute, `embedding_dim` is the feature dimension, `dtype` is the data type of the feature vector, `key_type` is the data type of feature ID.
 
-If two OneEmbeddings are created at the same time, different name and persistent path parameters are needed to be set during instantiation. For more detailes, please refer to [one_embedding.MultiTableEmbedding](https://oneflow.readthedocs.io/en/master/one_embedding.html#oneflow.one_embedding.MultiTableEmbedding).
+If two OneEmbeddings are created at the same time, different name and persistent path parameters are needed to be set during instantiation. For more detailes, please refer to [one_embedding.MultiTableEmbedding](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.one_embedding.MultiTableEmbedding.forward.html).
 
 ### Construct Graph for Training
 
@@ -175,7 +175,7 @@ table_ids = np.array([0, 1, 2, 0, 1, 2])
 # This means to query `488, 18` in the zeroth table, `333, 568` in the first table, and the corresponding feature vector of `220, 508` in the second table.
 embedding_lookup(ids, table_ids)
 ```
-For more details, please refer to  [MultiTableEmbedding.forward](https://oneflow.readthedocs.io/en/master/one_embedding.html#oneflow.one_embedding.MultiTableEmbedding.forward).
+For more details, please refer to  [MultiTableEmbedding.forward](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.one_embedding.MultiTableEmbedding.forward.html).
 
 ### How to Choose the Proper Storage Configuration 
 

--- a/en/docs/parallelism/03_consistent_tensor.md
+++ b/en/docs/parallelism/03_consistent_tensor.md
@@ -66,7 +66,7 @@ Output:
 
 ### Get Local Tensor from Global Tensor
 
-Call [to_local()](https://oneflow.readthedocs.io/en/master/tensor.html#oneflow.Tensor.to_local) to check the local tensor on a device.
+Call [to_local](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.Tensor.to_local.html) to check the local tensor on a device.
 
 === "Terminal 0"
     ```python
@@ -86,7 +86,7 @@ Call [to_local()](https://oneflow.readthedocs.io/en/master/tensor.html#oneflow.T
 
 ### Convert Local Tensor to Global Tensor
 
-Developers can create local tensor first, then convert it to global tensor with [Tensor.to_global](https://oneflow.readthedocs.io/en/master/tensor.html#oneflow.Tensor.to_global).
+Developers can create local tensor first, then convert it to global tensor with [Tensor.to_global](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.Tensor.to_global.html).
 
 Two local tensors with the shape of `(2,5)` are created separately on two devices. While after the `to_global` method, the global tensor with a shape of `(4,5)` is obtained.
 

--- a/en/docs/parallelism/04_2d-sbp.md
+++ b/en/docs/parallelism/04_2d-sbp.md
@@ -6,7 +6,7 @@ Since you have known about 1D SBP, this document introduces 2D SBP, which can mo
 
 ## 2D Devices Array
 
-We are already familiar with the placement configuration of 1D SBP. In the scenario of 1D SBP, configure the cluster through the [oneflow.placement](https://oneflow.readthedocs.io/en/master/placement.html#oneflow.placement) interface. For example, use the 0~3 GPU graphics in the cluster:
+We are already familiar with the placement configuration of 1D SBP. In the scenario of 1D SBP, configure the cluster through the [oneflow.placement](https://oneflow.readthedocs.io/en/v0.8.1/tensor_attributes.html?highlight=oneflow.placement#oneflow-placement) interface. For example, use the 0~3 GPU graphics in the cluster:
 
 ```python
 >>> placement1 = flow.placement("cuda", ranks=[0, 1, 2, 3])

--- a/en/docs/parallelism/04_2d-sbp.md
+++ b/en/docs/parallelism/04_2d-sbp.md
@@ -113,9 +113,9 @@ x = flow.randn(1, 2, 8)
 global_x = x.to_global(placement=PLACEMENT, sbp=BS0)
 pred = model(global_x)
 ```
-Here, we create a local tensor with shape `(1, 2, 8)`, and obtain the corresponding global tensor through [Tensor.to_global](https://oneflow.readthedocs.io/en/master/tensor.html#oneflow.Tensor.to_global) method. Finally, input it to the model for inference.
+Here, we create a local tensor with shape `(1, 2, 8)`, and obtain the corresponding global tensor through [Tensor.to_global](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.Tensor.to_global.html) method. Finally, input it to the model for inference.
 
-After obtaining the local tensor on current physical device through [Tensor.to_local](https://oneflow.readthedocs.io/en/master/tensor.html#oneflow.Tensor.to_local) method, we can output its shape and value to verify whether the data has been processed correctly:
+After obtaining the local tensor on current physical device through [Tensor.to_local](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.Tensor.to_local.html) method, we can output its shape and value to verify whether the data has been processed correctly:
 ```python
 local_x = global_x.to_local()
 print(f'{local_x.device}, {local_x.shape}, \n{local_x}')

--- a/en/docs/parallelism/05_ddp.md
+++ b/en/docs/parallelism/05_ddp.md
@@ -180,6 +180,6 @@ python3 -m oneflow.distributed.launch --nproc_per_node 2 ./ddp_train.py
 
 ### DistributedSampler
 
-The data used is manually distributed in this context to highlight `DistributedDataParallel`. However, in practical applications, you can directly use [DistributedSampler](https://oneflow.readthedocs.io/en/master/utils.html#oneflow.utils.data.distributed.DistributedSampler) with data parallel.
+The data used is manually distributed in this context to highlight `DistributedDataParallel`. However, in practical applications, you can directly use [DistributedSampler](https://oneflow.readthedocs.io/en/v0.8.1/utils.data.html?highlight=DistributedSampler#oneflow.utils.data.distributed.DistributedSampler) with data parallel.
 
 `DistributedSampler` will instantiate the Dataloader in each process, and each Dataloader instance will load a part of the complete data to automatically complete the data distribution.

--- a/en/docs/parallelism/05_ddp.md
+++ b/en/docs/parallelism/05_ddp.md
@@ -4,7 +4,7 @@ In [Common Distributed Parallel Strategies](./01_introduction.md), we introduced
 
 OneFlow provides two ways to accomplish data parallel, and one of them is to use the original concept of Oneflow to run data parallel training by configurating global tensor. This is also the **recommanded way** to run data parallel training on Oneflow.
 
-Besides, to facilitate the users who are transferring from PyTorch to OneFlow, OneFlow offers the interface consistent with PyTorch `torch.nn.parallel.DistributedDataParallel`,  [oneflow.nn.parallel.DistributedDataParallel](https://oneflow.readthedocs.io/en/master/nn.html#oneflow.nn.parallel.DistributedDataParallel) so that users can also conveniently extend single machine training to data parallel training. 
+Besides, to facilitate the users who are transferring from PyTorch to OneFlow, OneFlow offers the interface consistent with PyTorch `torch.nn.parallel.DistributedDataParallel`,  [oneflow.nn.parallel.DistributedDataParallel](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.parallel.DistributedDataParallel.html) so that users can also conveniently extend single machine training to data parallel training. 
 
 ## Run Data Parallel Training With SBP Configuration
 
@@ -170,7 +170,7 @@ Click "Code" below to expand the code of the above running script.
 There are only two differences between the data parallelism training code and the stand-alone single-card script:
 
 - Use `DistributedDataParallel` to wrap the module object (`m = ddp(m)`)
-- Use [get_rank](https://oneflow.readthedocs.io/en/master/oneflow.html#oneflow.env.get_rank) to get the current device number and distribute the data to the device.
+- Use [get_rank](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.env.get_rank.html) to get the current device number and distribute the data to the device.
 
 Then use `launcher` to run the script, leave everything else to OneFlow, which makes distributed training as simple as stand-alone single-card training:
 

--- a/en/docs/parallelism/06_pipeline.md
+++ b/en/docs/parallelism/06_pipeline.md
@@ -110,7 +110,7 @@ P1 = flow.placement("cuda", [1])
 
 `P0` and `P1` represent the 0th GPU and the 1st GPU on the 0th machine respectively.
 
-By calling [nn.Module.to_global](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.Module.html?highlight=nn.Module) or [Tensor.to_global](https://oneflow.readthedocs.io/en/master/tensor.html?highlight=to_global#oneflow.Tensor.to_global), the model or tensor will be distributed to the devices specified before, breaking a network into stages.
+By calling [nn.Module.to_global](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.Module.html) or [Tensor.to_global](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.Tensor.to_global.html), the model or tensor will be distributed to the devices specified before, breaking a network into stages.
 
 Here we define a `PipelineModule` that specifically sets the pipeline for each stage.
 

--- a/en/docs/parallelism/06_pipeline.md
+++ b/en/docs/parallelism/06_pipeline.md
@@ -110,7 +110,7 @@ P1 = flow.placement("cuda", [1])
 
 `P0` and `P1` represent the 0th GPU and the 1st GPU on the 0th machine respectively.
 
-By calling [nn.Module.to_global](https://oneflow.readthedocs.io/en/master/module.html?highlight=to_global#oneflow.nn.Module.to_global) or [Tensor.to_global](https://oneflow.readthedocs.io/en/master/tensor.html?highlight=to_global#oneflow.Tensor.to_global), the model or tensor will be distributed to the devices specified before, breaking a network into stages.
+By calling [nn.Module.to_global](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.Module.html?highlight=nn.Module) or [Tensor.to_global](https://oneflow.readthedocs.io/en/master/tensor.html?highlight=to_global#oneflow.Tensor.to_global), the model or tensor will be distributed to the devices specified before, breaking a network into stages.
 
 Here we define a `PipelineModule` that specifically sets the pipeline for each stage.
 

--- a/en/docs/parallelism/06_pipeline.md
+++ b/en/docs/parallelism/06_pipeline.md
@@ -65,8 +65,8 @@ The following code is a simple example that will run the network in [QUICKSTART]
         def __init__(self):
             super().__init__()
             self.module_pipeline = module_pipeline
-            self.module_pipeline.m_stage0.config.stage_id = 0
-            self.module_pipeline.m_stage1.config.stage_id = 1
+            self.module_pipeline.m_stage0.config.set_stage(stage_id=0, placement=P0)
+            self.module_pipeline.m_stage1.config.set_stage(stage_id=1, placement=P1)
             self.loss_fn = flow.nn.CrossEntropyLoss()
             self.config.set_gradient_accumulation_steps(2)
             self.add_optimizer(sgd)
@@ -150,15 +150,15 @@ In practice, each computing device can load data locally, and then convert the L
 
 ### Stage ID and Settings for Gradient Accumulation
 
-We can set Stage ID by setting the `config.stage_id` attribute of Module. The Stage ID is numbered starting from 0 and increasing by 1.
+We can call the method [config.set_stage](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.graph.block_config.BlockConfig.set_stage.html) of Module Config to set Stage ID and related Placement. The Stage ID are numbered from 0.
 
-Call `self.config.set_gradient_accumulation_steps` method to set the step size of gradient accumulation.
+We can call the method [config.set_gradient_accumulation_steps](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.graph.graph_config.GraphConfig.set_gradient_accumulation_steps.html#oneflow.nn.graph.graph_config.GraphConfig.set_gradient_accumulation_steps) to set the step size of gradient accumulation.
 
 The information needed to implement micro-batch in pipelining parallelism can be obtained by these two configurations.
 
 
 ```python
-    self.module_pipeline.m_stage0.config.stage_id = 0
-    self.module_pipeline.m_stage1.config.stage_id = 1
+    self.module_pipeline.m_stage0.config.set_stage(stage_id=0, placement=P0)
+    self.module_pipeline.m_stage1.config.set_stage(stage_id=1, placement=P1)
     self.config.set_gradient_accumulation_steps(2)
 ```


### PR DESCRIPTION
预览版本见： https://doombeaker.github.io/oneflow-documentation/

因为 API 文档 v0.8 发布后，目录结构变化。导致本仓库引用的链接失效。本 PR 对一些失效的链接进行修复。

API 文档都固定道 v0.8.1 版本。防止未来 API 文档的迭代和变动。

TODO ： 实践栏目中的 amp 和 activation checkpoing 文章未做改动，因为涉及到 API 可能已经完全变化，需要文章作者后续关注下（ @strint ） 