### PR TITLE
Update Example Code in Pipeline Parallelism

### DIFF
--- a/cn/docs/parallelism/06_pipeline.md
+++ b/cn/docs/parallelism/06_pipeline.md
@@ -65,8 +65,8 @@
         def __init__(self):
             super().__init__()
             self.module_pipeline = module_pipeline
-            self.module_pipeline.m_stage0.config.stage_id = 0
-            self.module_pipeline.m_stage1.config.stage_id = 1
+            self.module_pipeline.m_stage0.config.set_stage(0, P0)
+            self.module_pipeline.m_stage1.config.set_stage(1, P1)
             self.loss_fn = flow.nn.CrossEntropyLoss()
             self.config.set_gradient_accumulation_steps(2)
             self.add_optimizer(sgd)
@@ -144,12 +144,12 @@ P1 = flow.placement("cuda", ranks=[1])
 
 ### Stage ID 及 梯度累积设置
 
-通过设置 Module 的 `config.stage_id` 属性，设置 Stage ID，Stage ID 从 0 开始编号，依次加1。
+通过 [config.set_stage](https://oneflow.readthedocs.io/en/master/generated/oneflow.nn.graph.block_config.BlockConfig.set_stage.html#oneflow.nn.graph.block_config.BlockConfig.set_stage) 方法设置流水并行策略下 Module 的 Stage ID 和 Placement，Stage ID 从 0 开始编号，依次加1。
 调用 `self.config.set_gradient_accumulation_steps` 方法，设置梯度累积的步长。
 OneFlow 通过这两项配置，获取实现流水并行中的 micro batch 技术所需的信息。
 
 ```python
-    self.module_pipeline.m_stage0.config.stage_id = 0
-    self.module_pipeline.m_stage1.config.stage_id = 1
+    self.module_pipeline.m_stage0.config.set_stage(0, P0)
+    self.module_pipeline.m_stage1.config.set_stage(1, P1)
     self.config.set_gradient_accumulation_steps(2)
 ```

--- a/en/docs/parallelism/06_pipeline.md
+++ b/en/docs/parallelism/06_pipeline.md
@@ -65,8 +65,8 @@ The following code is a simple example that will run the network in [QUICKSTART]
         def __init__(self):
             super().__init__()
             self.module_pipeline = module_pipeline
-            self.module_pipeline.m_stage0.config.stage_id = 0
-            self.module_pipeline.m_stage1.config.stage_id = 1
+            self.module_pipeline.m_stage0.config.set_stage(0, P0)
+            self.module_pipeline.m_stage1.config.set_stage(1, P1)
             self.loss_fn = flow.nn.CrossEntropyLoss()
             self.config.set_gradient_accumulation_steps(2)
             self.add_optimizer(sgd)
@@ -150,7 +150,7 @@ In practice, each computing device can load data locally, and then convert the L
 
 ### Stage ID and Settings for Gradient Accumulation
 
-We can set Stage ID by setting the `config.stage_id` attribute of Module. The Stage ID is numbered starting from 0 and increasing by 1.
+We can set Stage ID and Placement in pipeline parallelism by [config.set_stage](https://oneflow.readthedocs.io/en/master/generated/oneflow.nn.graph.block_config.BlockConfig.set_stage.html#oneflow.nn.graph.block_config.BlockConfig.set_stage) method. The Stage ID is numbered starting from 0 and increasing by 1.
 
 Call `self.config.set_gradient_accumulation_steps` method to set the step size of gradient accumulation.
 
@@ -158,7 +158,7 @@ The information needed to implement micro-batch in pipelining parallelism can be
 
 
 ```python
-    self.module_pipeline.m_stage0.config.stage_id = 0
-    self.module_pipeline.m_stage1.config.stage_id = 1
+    self.module_pipeline.m_stage0.config.set_stage(0, P0)
+    self.module_pipeline.m_stage1.config.set_stage(1, P1)
     self.config.set_gradient_accumulation_steps(2)
 ```


### PR DESCRIPTION
更新《流水并行训练》中的示例代码，`config.stage_id = i` 在最新版 OneFlow 中已过时，需要替换为 `config.set_stage(i, placement)`

```
Warning: `config.stage_id = i` is deprecated, please use config.set_stage(i, placement) for easy and efficient Pipeline parallel experience.
```