### PR TITLE
Modify some oneflow-documentation errors

### DIFF
--- a/cn/docs/cookies/activation_checkpointing.md
+++ b/cn/docs/cookies/activation_checkpointing.md
@@ -40,7 +40,7 @@ optimizer = flow.optim.SGD([{'params': model_part1.parameters()},
                            lr=1e-3)
 ```
 
-如果要开启 activation checkpointing，只需在 [nn.Graph](../basics/08_nn_graph.md) 模型中的 Eager 模型成员 (即 nn.Module 对象) 上指定 `.config.activation_checkpointing = True`。此 API 详见：[activation_checkpointing](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.graph.block_config.BlockConfig.activation_checkpointing.html)。对于每个打开 "activation checkpointing" 的 nn.Module，其输入 activation 将会被保留，而其它中间 activation 在反向传播过程中被使用时会被重新计算。
+如果要开启 activation checkpointing，只需在 [nn.Graph](../basics/08_nn_graph.md) 模型中的 Eager 模型成员 (即 nn.Module 对象) 利用`.to(nn.graph.GraphModule)`方法转换为`nn.graph.GraphModule`对象，并在其上指定 `.activation_checkpointing = True`。此 API 详见：[activation_checkpointing](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.graph.block_config.BlockConfig.activation_checkpointing.html)。对于每个打开 "activation checkpointing" 的 nn.Module，其输入 activation 将会被保留，而其它中间 activation 在反向传播过程中被使用时会被重新计算。
 
 ```python
 class CustomGraph(flow.nn.Graph):
@@ -49,8 +49,8 @@ class CustomGraph(flow.nn.Graph):
         self.model_part1 = model_part1
         self.model_part2 = model_part2
         # 在连续的两个 nn.Module 上开启 activation checkpointing
-        self.model_part1.config.activation_checkpointing = True
-        self.model_part2.config.activation_checkpointing = True
+        self.model_part1.to(nn.graph.GraphModule).activation_checkpointing = True
+        self.model_part2.to(nn.graph.GraphModule).activation_checkpointing = True
         self.loss_fn = loss_fn
         self.add_optimizer(optimizer)
 

--- a/cn/docs/cookies/activation_checkpointing.md
+++ b/cn/docs/cookies/activation_checkpointing.md
@@ -40,7 +40,7 @@ optimizer = flow.optim.SGD([{'params': model_part1.parameters()},
                            lr=1e-3)
 ```
 
-如果要开启 activation checkpointing，只需在 [nn.Graph](../basics/08_nn_graph.md) 模型中的 Eager 模型成员 (即 nn.Module 对象) 利用`.to(nn.graph.GraphModule)`方法转换为`nn.graph.GraphModule`对象，并在其上指定 `.activation_checkpointing = True`。此 API 详见：[activation_checkpointing](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.graph.block_config.BlockConfig.activation_checkpointing.html)。对于每个打开 "activation checkpointing" 的 nn.Module，其输入 activation 将会被保留，而其它中间 activation 在反向传播过程中被使用时会被重新计算。
+如果要开启 activation checkpointing，只需在 [nn.Graph](../basics/08_nn_graph.md) 模型中的 Eager 模型成员 (即 nn.Module 对象) 利用 `.to(nn.graph.GraphModule)` 方法转换为 `nn.graph.GraphModule` 对象，并在其上指定 `.activation_checkpointing = True`。此 API 详见：[activation_checkpointing](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.graph.block_config.BlockConfig.activation_checkpointing.html)。对于每个打开 "activation checkpointing" 的 nn.Module，其输入 activation 将会被保留，而其它中间 activation 在反向传播过程中被使用时会被重新计算。
 
 ```python
 class CustomGraph(flow.nn.Graph):

--- a/cn/docs/cookies/global_tensor_distributed.md
+++ b/cn/docs/cookies/global_tensor_distributed.md
@@ -261,8 +261,8 @@ OneFlow 同时支持 `Eager 模式` 和 `Graph 模式` 两种模型运行方式�
         def __init__(self):
             super().__init__()
             self.model = ModuleModel()
-            self.model.m_stage0.config.set_stage(stage_id=0, placement=P01)
-            self.model.m_stage1.config.set_stage(stage_id=1, placement=P23)
+            self.model.m_stage0.to(nn.graph.GraphModule).set_stage(stage_id=0, placement=P01)
+            self.model.m_stage1.to(nn.graph.GraphModule).set_stage(stage_id=1, placement=P23)
 
         def build(self, x):
             return self.model(x)

--- a/cn/docs/cookies/save_load.md
+++ b/cn/docs/cookies/save_load.md
@@ -113,7 +113,7 @@ OrderedDict([('weight', tensor([[1., 1.],
 ```python
 import os
 import numpy as np
-
+import oneflow.nn as nn
 import oneflow as flow
 
 model_tensor_placement = flow.placement("cuda", ranks=[0, 1, 2, 3])
@@ -200,10 +200,10 @@ class PipelineGraph(flow.nn.Graph):
     def __init__(self, module_pipeline):
         super().__init__()
         self.module_pipeline = module_pipeline
-        self.module_pipeline.m_stage0.config.set_stage(0, P0)
-        self.module_pipeline.m_stage1.config.set_stage(1, P1)
-        self.module_pipeline.m_stage2.config.set_stage(2, P2)
-        self.module_pipeline.m_stage3.config.set_stage(3, P3)
+        self.module_pipeline.m_stage0.to(nn.graph.GraphModule).set_stage(0, P0)
+        self.module_pipeline.m_stage1.to(nn.graph.GraphModule).set_stage(1, P1)
+        self.module_pipeline.m_stage2.to(nn.graph.GraphModule).set_stage(2, P2)
+        self.module_pipeline.m_stage3.to(nn.graph.GraphModule).set_stage(3, P3)
         self.config.set_gradient_accumulation_steps(2)
         self.add_optimizer(
             flow.optim.SGD(self.module_pipeline.parameters(), lr=0.001)

--- a/cn/docs/parallelism/06_pipeline.md
+++ b/cn/docs/parallelism/06_pipeline.md
@@ -65,8 +65,8 @@
         def __init__(self):
             super().__init__()
             self.module_pipeline = module_pipeline
-            self.module_pipeline.m_stage0.config.set_stage(stage_id=0, placement=P0)
-            self.module_pipeline.m_stage1.config.set_stage(stage_id=1, placement=P1)
+            self.module_pipeline.m_stage0.to(nn.graph.GraphModule).set_stage(stage_id=0, placement=P0)
+            self.module_pipeline.m_stage1.to(nn.graph.GraphModule).set_stage(stage_id=1, placement=P1)
             self.loss_fn = flow.nn.CrossEntropyLoss()
             self.config.set_gradient_accumulation_steps(2)
             self.add_optimizer(sgd)
@@ -144,12 +144,13 @@ P1 = flow.placement("cuda", ranks=[1])
 
 ### Stage ID 及梯度累积设置
 
-通过 Module Config 上的 [config.set_stage](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.graph.block_config.BlockConfig.set_stage.html) 方法，设置流水线 Stage ID 和 Stage 对应的 Placement，Stage ID 从 0 开始编号，依次加 1。
+当[nn.Module](https://oneflow.readthedocs.io/en/master/nn.html?highlight=nn.Module#nn-module)的一个实例化网络层作为属性加入继承于[nn.Graph](https://oneflow.readthedocs.io/en/master/graph.html)的新类时，内部会将该网络层用`ProxyModule`进行包装，利用方法`.to(nn.graph.GraphModule)`得到一个`nn.graph.GraphModule`的实例化对象，然后使用方法`stage_id`设置流水线 Stage ID 和 Stage 对应的 Placement，Stage ID 从 0 开始编号，依次加 1。
+
 调用 [config.set_gradient_accumulation_steps](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.graph.graph_config.GraphConfig.set_gradient_accumulation_steps.html#oneflow.nn.graph.graph_config.GraphConfig.set_gradient_accumulation_steps) 方法，设置梯度累积的步长。
 OneFlow 通过这两项配置，获取实现流水并行中的 micro batch 技术所需的信息。
 
 ```python
-    self.module_pipeline.m_stage0.config.set_stage(stage_id=0, placement=P0)
-    self.module_pipeline.m_stage1.config.set_stage(stage_id=1, placement=P1)
+    self.module_pipeline.m_stage0.to(nn.graph.GraphModule).set_stage(stage_id=0, placement=P0)
+    self.module_pipeline.m_stage1.to(nn.graph.GraphModule).set_stage(stage_id=1, placement=P1)
     self.config.set_gradient_accumulation_steps(2)
 ```

--- a/cn/docs/parallelism/06_pipeline.md
+++ b/cn/docs/parallelism/06_pipeline.md
@@ -144,7 +144,7 @@ P1 = flow.placement("cuda", ranks=[1])
 
 ### Stage ID 及梯度累积设置
 
-当[nn.Module](https://oneflow.readthedocs.io/en/master/nn.html?highlight=nn.Module#nn-module)的一个实例化网络层作为属性加入继承于[nn.Graph](https://oneflow.readthedocs.io/en/master/graph.html)的新类时，内部会将该网络层用`ProxyModule`进行包装，利用方法`.to(nn.graph.GraphModule)`得到一个`nn.graph.GraphModule`的实例化对象，然后使用方法`stage_id`设置流水线 Stage ID 和 Stage 对应的 Placement，Stage ID 从 0 开始编号，依次加 1。
+当[nn.Module](https://oneflow.readthedocs.io/en/master/nn.html?highlight=nn.Module#nn-module)的一个实例化网络层作为属性加入继承于[nn.Graph](https://oneflow.readthedocs.io/en/master/graph.html)的新类时，内部会将该网络层用`ProxyModule`进行包装，利用方法`.to`得到一个`nn.graph.GraphModule`的实例化对象，然后使用方法`stage_id`设置流水线 Stage ID 和 Stage 对应的 Placement，Stage ID 从 0 开始编号，依次加 1。
 
 调用 [config.set_gradient_accumulation_steps](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.graph.graph_config.GraphConfig.set_gradient_accumulation_steps.html#oneflow.nn.graph.graph_config.GraphConfig.set_gradient_accumulation_steps) 方法，设置梯度累积的步长。
 OneFlow 通过这两项配置，获取实现流水并行中的 micro batch 技术所需的信息。

--- a/cn/docs/parallelism/06_pipeline.md
+++ b/cn/docs/parallelism/06_pipeline.md
@@ -144,7 +144,7 @@ P1 = flow.placement("cuda", ranks=[1])
 
 ### Stage ID 及梯度累积设置
 
-当[nn.Module](https://oneflow.readthedocs.io/en/master/nn.html?highlight=nn.Module#nn-module)的一个实例化网络层作为属性加入继承于[nn.Graph](https://oneflow.readthedocs.io/en/master/graph.html)的新类时，内部会将该网络层用`ProxyModule`进行包装，利用方法`.to`得到一个`nn.graph.GraphModule`的实例化对象，然后使用方法`stage_id`设置流水线 Stage ID 和 Stage 对应的 Placement，Stage ID 从 0 开始编号，依次加 1。
+当 [nn.Module](https://oneflow.readthedocs.io/en/master/nn.html?highlight=nn.Module#nn-module) 的一个实例化网络层作为属性加入继承于 [nn.Graph](https://oneflow.readthedocs.io/en/master/graph.html) 的新类时，内部会将该网络层用 `ProxyModule` 进行包装，利用方法 `.to` 得到一个 `nn.graph.GraphModule` 的实例化对象，然后使用方法 `stage_id` 设置流水线 Stage ID 和 Stage 对应的 Placement，Stage ID 从 0 开始编号，依次加 1。
 
 调用 [config.set_gradient_accumulation_steps](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.graph.graph_config.GraphConfig.set_gradient_accumulation_steps.html#oneflow.nn.graph.graph_config.GraphConfig.set_gradient_accumulation_steps) 方法，设置梯度累积的步长。
 OneFlow 通过这两项配置，获取实现流水并行中的 micro batch 技术所需的信息。

--- a/en/docs/cookies/activation_checkpointing.md
+++ b/en/docs/cookies/activation_checkpointing.md
@@ -40,7 +40,7 @@ optimizer = flow.optim.SGD([{'params': model_part1.parameters()},
                            lr=1e-3)
 ```
 
-To turn on activation checkpointing, you only need to specify `.config.activation_checkpointing = True` on the Eager model member (i.e. the nn.Module object) in the [nn.Graph](../basics/08_nn_graph.md) model. For more details of this API, please refer to: [activation_checkpointing](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.graph.block_config.BlockConfig.activation_checkpointing.html). For each nn.Module with "activation checkpointing" turned on, its input activations will be preserved, while other intermediate activations will be recomputed when used during backpropagation.
+To turn on activation checkpointing, you only need to use method `.to(nn.graph.GraphModule)` on the Eager model member (i.e. the nn.Module object) to get `nn.graph.GraphModule` object. And then modify corresponding attribute as `.activation_checkpointing = True` on the `nn.graph.GraphModule`. For more details of this API, please refer to: [activation_checkpointing](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.graph.block_config.BlockConfig.activation_checkpointing.html). For each nn.Module with "activation checkpointing" turned on, its input activations will be preserved, while other intermediate activations will be recomputed when used during backpropagation.
 
 ```python
 class CustomGraph(flow.nn.Graph):
@@ -49,8 +49,8 @@ class CustomGraph(flow.nn.Graph):
         self.model_part1 = model_part1
         self.model_part2 = model_part2
         # Turn on activation checkpointing on two consecutive nn.Module
-        self.model_part1.config.activation_checkpointing = True
-        self.model_part2.config.activation_checkpointing = True
+        self.model_part1.to(nn.graph.GraphModule).activation_checkpointing = True
+        self.model_part2.to(nn.graph.GraphModule).activation_checkpointing = True
         self.loss_fn = loss_fn
         self.add_optimizer(optimizer)
 

--- a/en/docs/cookies/global_tensor_distributed.md
+++ b/en/docs/cookies/global_tensor_distributed.md
@@ -262,8 +262,8 @@ The following example is a mixed parallelism program for `4 GPUs`.
         def __init__(self):
             super().__init__()
             self.model = ModuleModel()
-            self.model.m_stage0.config.set_stage(stage_id=0, placement=P01)
-            self.model.m_stage1.config.set_stage(stage_id=1, placement=P23)
+            self.model.m_stage0.to(nn.graph.GraphModule).set_stage(stage_id=0, placement=P01)
+            self.model.m_stage1.to(nn.graph.GraphModule).set_stage(stage_id=1, placement=P23)
             
         def build(self, x):
             return self.model(x)

--- a/en/docs/cookies/save_load.md
+++ b/en/docs/cookies/save_load.md
@@ -203,10 +203,10 @@ class PipelineGraph(flow.nn.Graph):
     def __init__(self, module_pipeline):
         super().__init__()
         self.module_pipeline = module_pipeline
-        self.module_pipeline.m_stage0.config.set_stage(0, P0)
-        self.module_pipeline.m_stage1.config.set_stage(1, P1)
-        self.module_pipeline.m_stage2.config.set_stage(2, P2)
-        self.module_pipeline.m_stage3.config.set_stage(3, P3)
+        self.module_pipeline.m_stage0.to(nn.graph.GraphModule).set_stage(0, P0)
+        self.module_pipeline.m_stage1.to(nn.graph.GraphModule).set_stage(1, P1)
+        self.module_pipeline.m_stage2.to(nn.graph.GraphModule).set_stage(2, P2)
+        self.module_pipeline.m_stage3.to(nn.graph.GraphModule).set_stage(3, P3)
         self.config.set_gradient_accumulation_steps(2)
         self.add_optimizer(
             flow.optim.SGD(self.module_pipeline.parameters(), lr=0.001)

--- a/en/docs/parallelism/06_pipeline.md
+++ b/en/docs/parallelism/06_pipeline.md
@@ -65,8 +65,8 @@ The following code is a simple example that will run the network in [QUICKSTART]
         def __init__(self):
             super().__init__()
             self.module_pipeline = module_pipeline
-            self.module_pipeline.m_stage0.config.set_stage(stage_id=0, placement=P0)
-            self.module_pipeline.m_stage1.config.set_stage(stage_id=1, placement=P1)
+            self.module_pipeline.m_stage0.to(nn.graph.GraphModule).set_stage(stage_id=0, placement=P0)
+            self.module_pipeline.m_stage1.to(nn.graph.GraphModule).set_stage(stage_id=1, placement=P1)
             self.loss_fn = flow.nn.CrossEntropyLoss()
             self.config.set_gradient_accumulation_steps(2)
             self.add_optimizer(sgd)
@@ -150,7 +150,7 @@ In practice, each computing device can load data locally, and then convert the L
 
 ### Stage ID and Settings for Gradient Accumulation
 
-We can call the method [config.set_stage](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.graph.block_config.BlockConfig.set_stage.html) of Module Config to set Stage ID and related Placement. The Stage ID are numbered from 0.
+When [nn. Module](https://oneflow.readthedocs.io/en/master/nn.html?highlight=nn.Module#nn-Module) as an attribute inherited from [nn. Graph](https://oneflow.readthedocs.io/en/master/graph.html). The network layer will be wrapped internally with `ProxyModule`, and a `nn.graph.GraphModule` object will be obtained by using the `to` method, and then use the method `stage_ Id` to set the stage ID of the pipeline and the placement corresponding to the stage. The stage ID starts from 0 and increases by 1.
 
 We can call the method [config.set_gradient_accumulation_steps](https://oneflow.readthedocs.io/en/v0.8.1/generated/oneflow.nn.graph.graph_config.GraphConfig.set_gradient_accumulation_steps.html#oneflow.nn.graph.graph_config.GraphConfig.set_gradient_accumulation_steps) to set the step size of gradient accumulation.
 
@@ -158,7 +158,7 @@ The information needed to implement micro-batch in pipelining parallelism can be
 
 
 ```python
-    self.module_pipeline.m_stage0.config.set_stage(stage_id=0, placement=P0)
-    self.module_pipeline.m_stage1.config.set_stage(stage_id=1, placement=P1)
+    self.module_pipeline.m_stage0.to(nn.graph.GraphModule).set_stage(stage_id=0, placement=P0)
+    self.module_pipeline.m_stage1.to(nn.graph.GraphModule).set_stage(stage_id=1, placement=P1)
     self.config.set_gradient_accumulation_steps(2)
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ mkdocs-material-extensions==1.0.1
 mike==1.0.1
 Jinja2==3.0.2
 mkdocs-redirects==1.0.4
+Pygments==2.13.0


### PR DESCRIPTION
文档校正后的[在线浏览链接](https://process852.github.io/oneflow-documentation/)

* 修正由于[API](https://github.com/Oneflow-Inc/oneflow/issues/9457)改动造成的[文档](https://docs.oneflow.org/master/)错误
    - https://github.com/Oneflow-Inc/oneflow/issues/9457
* 改动后代码块的测试结果https://github.com/Oneflow-Inc/oneflow-documentation/pull/517#issuecomment-1345828801
* 改动界面主要是以下几个
1. [流水并行训练](https://process852.github.io/oneflow-documentation/master/parallelism/06_pipeline.html)
2. [使用 Global Tensor 进行分布式编程：分布式并行策略](https://process852.github.io/oneflow-documentation/master/cookies/global_tensor_distributed.html)
3. [Activation Checkpointing](https://process852.github.io/oneflow-documentation/master/cookies/activation_checkpointing.html)
4. [大模型分片保存和加载](https://process852.github.io/oneflow-documentation/master/cookies/save_load.html)